### PR TITLE
Service on boot

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -39,6 +39,7 @@ class stash::service {
   if $stash::manage_service {
       service { 'stash':
       ensure    => 'running',
+      enable    => true,
       provider  => base,
       start     => '/etc/init.d/stash start',
       restart   => '/etc/init.d/stash restart',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -40,7 +40,6 @@ class stash::service {
       service { 'stash':
       ensure    => 'running',
       enable    => true,
-      provider  => base,
       start     => '/etc/init.d/stash start',
       restart   => '/etc/init.d/stash restart',
       stop      => '/etc/init.d/stash stop',


### PR DESCRIPTION
Hi Merritt,

This PR fixes: https://github.com/mkrakowitzer/puppet-stash/issues/10 -- service not starting on boot.

You were just missing an 'enable' parameter and the 'provider' setting prevented the init script links being created.  I'm curious as to what the intention was specifying the provider - was there a specifc problem you were having?

Cheers,
Geoff
