### PR TITLE
fix path to ruby executable on puppet enterprise

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -19,6 +19,15 @@ class stash::facts(
   $port   = '7990',
   $uri    = '127.0.0.1',
 ) {
+
+  # Puppet Enterprise supplies its own ruby version if your using it.
+  # A modern ruby version is required to run the executable fact
+  if $::puppetversion =~ /Puppet Enterprise/ {
+    $ruby_bin = "/opt/puppet/bin/ruby"
+  } else {
+    $ruby_bin = "/usr/bin/env ruby"
+  }
+
   file { '/etc/facter/facts.d/stash_facts.rb':
     ensure  => $ensure,
     content => template('stash/facts.rb.erb'),

--- a/spec/classes/stash_facts_spec.rb
+++ b/spec/classes/stash_facts_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper.rb'
+describe 'stash' do
+describe 'stash::facts' do
+    regexp_pe = /^#\!\/opt\/puppet\/bin\/ruby$/
+    regexp_oss = /^#\!\/usr\/bin\/env ruby$/
+    external_fact_file = '/etc/facter/facts.d/stash_facts.rb'
+
+    it { should contain_file(external_fact_file) }
+
+    # Test puppet enterprise shebang generated correctly
+    context 'with puppet enterprise' do
+        let(:facts) { {:puppetversion => "3.4.3 (Puppet Enterprise 3.2.1)"} }
+        it do
+          should contain_file(external_fact_file) \
+            .with_content(regexp_pe)
+        end
+    end
+    # Test puppet oss shebang generated correctly
+    context 'with puppet oss' do
+        let(:facts) { {:puppetversion => "all other versions"} }
+        it do
+          should contain_file(external_fact_file) \
+            .with_content(regexp_oss)
+        end
+    end
+end
+end

--- a/templates/facts.rb.erb
+++ b/templates/facts.rb.erb
@@ -1,4 +1,4 @@
-#!/usr//bin/ruby
+#!<%= @ruby_bin %>
 # Fact: stash_builddate, stash_buildnumber, stash_displayname, stash_version
 #
 # Purpose: Return facts for the running version of stash.


### PR DESCRIPTION
Hi Merritt,

I've put together a fix for for https://github.com/mkrakowitzer/puppet-stash/issues/12 -- which stops the external facts in this module from working with Puppet Enterprise in some situations.

I've changed the shebang in the external facts script to be sourced from a variable instead of hardcoded and am switching the Ruby interpreter based on the value of the $::puppetversion fact.
- Puppet Enterprise will source ruby from "/opt/puppet/bin/ruby"
- Puppet OSS will source ruby from "'/usr/bin/env ruby" -- this is more portable then hardcoding the full path to Ruby

I've added tests for the above in the file spec/classes/stash_facts_spec.rb

Cheers,
Geoff
