### PR TITLE
Allow git package to be specified elsewhere and a specificversion to be installed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,6 +70,9 @@ class stash(
 
   # Reverse https proxy
   $proxy = {},
+
+  # Git version
+  $git_version = 'installed'
 ) {
 
   $webappdir    = "${installdir}/atlassian-${product}-${version}"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -45,13 +45,16 @@ class stash::install(
   $group       = $stash::group,
   $uid         = $stash::uid,
   $gid         = $stash::gid,
+  $git_version = $stash::git_version,
 
   $downloadURL = $stash::downloadURL,
   $webappdir
   ) {
 
   if ! defined(Package['git']) {
-    package { 'git': ensure => installed }
+    package { 'git':
+      ensure => $git_version,
+    }
   }
 
   group { $group:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -50,7 +50,9 @@ class stash::install(
   $webappdir
   ) {
 
-  package { 'git': ensure => installed }
+  if ! defined(Package['git']) {
+    package { 'git': ensure => installed }
+  }
 
   group { $group:
     ensure => present,

--- a/spec/classes/stash_install_spec.rb
+++ b/spec/classes/stash_install_spec.rb
@@ -74,4 +74,34 @@ describe 'stash::install' do
     end
   end
 
+  context 'specify git version' do
+    let(:params) {{
+      :user  => 'stash',
+      :group => 'stash',
+      :installdir => '/opt/stash',
+      :homedir => '/home/stash',
+      :format => 'tar.gz',
+      :product => 'stash',
+      :version => '2.12.0',
+      :downloadURL => 'http://www.atlassian.com/software/stash/downloads/binary/',
+      :webappdir => '/opt/stash/atlassian-stash-2.12.0',
+      :git_version => '1.7.12'
+      }}
+
+    it 'should ensure a specific version of git is installed' do
+      should contain_package('git').with_ensure('1.7.12')
+    end
+    it { should contain_group('stash') }
+    it { should contain_user('stash').with_shell('/bin/bash') }
+    it 'should deploy stash 2.12.0 from tar.gz' do
+      should contain_deploy__file("atlassian-stash-2.12.0.tar.gz")
+    end
+    it 'should manage the stash home directory' do
+      should contain_file('/home/stash').with({
+        'ensure' => 'directory',
+        'owner' => 'stash',
+        'group' => 'stash'
+        })
+    end
+  end
 end

--- a/spec/classes/stash_install_spec.rb
+++ b/spec/classes/stash_install_spec.rb
@@ -12,7 +12,8 @@ describe 'stash::install' do
       :product => 'stash',
       :version => '2.12.0',
       :downloadURL => 'http://www.atlassian.com/software/stash/downloads/binary/',
-      :webappdir => '/opt/stash/atlassian-stash-2.12.0'
+      :webappdir => '/opt/stash/atlassian-stash-2.12.0',
+      :git_version => 'installed'
       }}
 
     it 'should install, but not upgrade, git' do
@@ -44,7 +45,8 @@ describe 'stash::install' do
       :uid   => 333,
       :gid   => 444,
       :downloadURL => 'http://downloads.atlassian.com/',
-      :webappdir => '/somewhere/stash'
+      :webappdir => '/somewhere/stash',
+      :git_version => 'installed'
       }}
 
     it { should contain_user('foo').with({


### PR DESCRIPTION
The default version of git that is installed in CentOS6.5 is too early to be used with the current version of stash.  These changes allow for git to be installed outside of the module. Additionally the version of git can be specified when installing stash.
