### PR TITLE
Enable upgrading of stash without manual intervention

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'mkrakowitzer-stash'
-version '0.0.2'
+version '1.0.0'
 source 'https://github.com/mkrakowitzer/puppet-stash.git'
 author 'mkrakowitzer'
 license 'The MIT License (MIT)'

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Customization
 -------------
 This module also allows for direct customization of the JVM, following [atlassians recommendations](https://confluence.atlassian.com/display/JIRA/Setting+Properties+and+Options+on+Startup)
 
-This is especially useful for setting properties such as http/https proxy settings.
+This is especially useful for setting properties such as HTTP/https proxy settings.
 
-Support has also been added for reverse proxying stash via apache or nginx.
+Support has also been added for reverse proxying stash via Apache or nginx.
 
 ```puppet
   class { 'stash':
@@ -62,7 +62,19 @@ Support has also been added for reverse proxying stash via apache or nginx.
   }
 ```
 
-Paramaters
+Upgrading Stash
+---------------
+It is now possible to cleanly upgrade stash by incrementing the version number.
+You must have included the stash::facts class prior to incrementing version numbers.
+
+```puppet
+  class { 'stash::facts': }
+```
+
+If the current running version of stash is less than the expected version of stash. 
+The module will stop the existing version of stash in preparation for upgrade.
+
+Parameters
 ----------
 ####`javahome`
 Specify the java home directory. No assumptions are made re the location of java and therefor this option is required. Default: undef
@@ -129,17 +141,6 @@ ruby-1.9.3-p484/bin/ruby -S rspec spec/classes/stash_install_spec.rb --color
 Finished in 0.38159 seconds
 1 example, 0 failures
 ```
-Support
--------
-Incrementing version numbers will upgrade stash. However there is some manual steps required:
-* stop stash
-* increment version number
-* run puppet. 
-* When upgraded from <3.2.0 to >=3.2.0 puppet will not run through cleanly as stash has some migration tasks to complete. Start stash, run puppet.
-
-Todo
-----
-Allow stash to upgrade automatically by incrementing the version number without manual intervention.
 
 License
 -------

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -28,6 +28,10 @@ class stash::facts(
     $ruby_bin = '/usr/bin/env ruby'
   }
 
+  package { [ 'rubygem-json', 'ruby-json' ]:
+    ensure => present,
+  }
+
   file { '/etc/facter/facts.d/stash_facts.rb':
     ensure  => $ensure,
     content => template('stash/facts.rb.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@ class stash(
   $java_opts    = '',
 
   # Stash Settings
-  $version      = '3.2.4',
+  $version      = '3.3.0',
   $product      = 'stash',
   $format       = 'tar.gz',
   $installdir   = '/opt/stash',
@@ -45,7 +45,21 @@ class stash(
   $repoforge   = true,
 ) {
 
+  Exec { path => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ] }
+
   $webappdir    = "${installdir}/atlassian-${product}-${version}"
+
+  if $::stash_version {
+    # If the running version of stash is less than the expected version of stash
+    # Shut it down in preparation for upgrade.
+    if versioncmp($version, $::stash_version) > 0 {
+      notify { 'Attempting to upgrade stash': }
+      exec { 'service stash stop && sleep 15': }
+      if versioncmp($version, '3.2.0') > 0 {
+        exec { "rm -f ${homedir}/stash-config.properties": }
+      }
+    }
+  }
 
   anchor { 'stash::start':
   } ->

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "mkrakowitzer-stash",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "author": "mkrakowitzer",
   "summary": "Install atlassian stash",
   "license": "The MIT License (MIT)",

--- a/spec/classes/stash_config_spec.rb
+++ b/spec/classes/stash_config_spec.rb
@@ -2,11 +2,14 @@ require 'spec_helper.rb'
 
 describe 'stash' do
 describe 'stash::config' do
-	context 'default params' do
-		it { should contain_file('/opt/stash/atlassian-stash-3.2.4/bin/setenv.sh')}
-		it { should contain_file('/opt/stash/atlassian-stash-3.2.4/bin/user.sh')}
-		it { should contain_file('/opt/stash/atlassian-stash-3.2.4/conf/server.xml')}
-		it { should contain_file('/home/stash/shared/stash-config.properties')}
-	end
+  context 'default params' do
+    let(:params) {{
+      :version => '3.2.4',
+    }}
+    it { should contain_file('/opt/stash/atlassian-stash-3.2.4/bin/setenv.sh')}
+    it { should contain_file('/opt/stash/atlassian-stash-3.2.4/bin/user.sh')}
+    it { should contain_file('/opt/stash/atlassian-stash-3.2.4/conf/server.xml')}
+    it { should contain_file('/home/stash/shared/stash-config.properties')}
+  end
 end
 end

--- a/templates/facts.rb.erb
+++ b/templates/facts.rb.erb
@@ -17,5 +17,5 @@ pinfo.each do |key, value|
   if value.is_a? Array
      actual_value = value.join(',')
   end
-  puts "stash_#{key.chomp()} = #{actual_value.chomp}"
+  puts "stash_#{key.chomp()}=#{actual_value.chomp}"
 end

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -25,12 +25,10 @@
     -->
     <!--APR library loader. Documentation at /docs/apr.html -->
     <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
-    <!--Initialize Jasper prior to webapps are loaded. Documentation at /docs/jasper-howto.html -->
-    <Listener className="org.apache.catalina.core.JasperListener" />
     <!-- Prevent memory leaks due to use of particular java/javax APIs-->
     <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
     <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
-    <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+    <!--Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" /-->
 
     <!-- Global JNDI resources
          Documentation at /docs/jndi-resources-howto.html
@@ -47,10 +45,10 @@
     </GlobalNamingResources>
 
     <!-- A "Service" is a collection of one or more "Connectors" that share
-        a single "Container" Note:  A "Service" is not itself a "Container",
-        so you may not define subcomponents such as "Valves" at this level.
-        Documentation at /docs/config/service.html
-    -->
+         a single "Container" Note:  A "Service" is not itself a "Container",
+         so you may not define subcomponents such as "Valves" at this level.
+         Documentation at /docs/config/service.html
+     -->
     <Service name="Catalina">
 
         <!--The connectors can use a shared executor, you can define one or more named thread pools-->
@@ -68,10 +66,9 @@
              Define a non-SSL HTTP/1.1 Connector on port 7990
 
              If you change this port, you have to update scripts.cfg as well
-             to have the same port configuration. 
+             to have the same port configuration.
         -->
-        <Connector port="7990"
-                   protocol="HTTP/1.1"
+        <Connector port="7990" protocol="HTTP/1.1"
                    connectionTimeout="20000"
                    useBodyEncodingForURI="true"
                    redirectPort="8443"
@@ -92,12 +89,13 @@
                    redirectPort="8443" />
         -->
         <!-- Define a SSL HTTP/1.1 Connector on port 8443
-             This connector uses the JSSE configuration, when using APR, the
-             connector should be using the OpenSSL style configuration
-             described in the APR documentation -->
+             This connector uses the NIO implementation that requires the JSSE
+             style configuration. When using the APR/native implementation, the
+             OpenSSL style configuration is required as described in the APR/native
+             documentation -->
         <!--
-        <Connector port="8443" protocol="HTTP/1.1" SSLEnabled="true"
-                   maxThreads="150" scheme="https" secure="true"
+        <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+                   maxThreads="150" SSLEnabled="true" scheme="https" secure="true"
                    clientAuth="false" sslProtocol="TLS" />
         -->
 
@@ -131,19 +129,15 @@
                        resourceName="UserDatabase"/>
             </Realm>
 
-
             <Host name="localhost" appBase="webapps"
                   unpackWARs="true" autoDeploy="true"
                   xmlValidation="false" xmlNamespaceAware="false">
 
+                <!-- Before changing the context path for Stash, please read our documentation:
+                     https://confluence.atlassian.com/x/5oCNEQ
 
-               <!-- Before changing the context path for Stash, please read our documentation: 
-                        https://confluence.atlassian.com/x/5oCNEQ
-
-                    You will have to update scripts.cfg AND 
-                    rename webapps/ROOT directory.  
-   
-                -->
+                     You will have to update scripts.cfg
+                     AND rename webapps/ROOT directory. -->
 
                 <Context docBase="${catalina.home}/atlassian-stash"
                          path=""
@@ -161,7 +155,7 @@
                      Note: The pattern used is equivalent to using pattern="common" -->
                 <!--
                 <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-                       prefix="localhost_access_log." suffix=".txt"
+                       prefix="localhost_access_log" suffix=".txt"
                        pattern="%h %l %u %t &quot;%r&quot; %s %b" />
                 -->
             </Host>


### PR DESCRIPTION
- tested upgrades:
-    2.10.1 to 3.2.4 to 3.3.0
-    2.10.1 to 3.3.0

minor updates
- remove spaces from facts template.
- bump stash to version 3.3.0
- update readme
- bump module to 1.0.0
- update server.xml to work with 3.3.0, tested in 2.10.1 and 3.2.4 for compatibility.

Tested on RHEL6.
TODO: test on RHEL5/Ubuntu 12.04
