### PR TITLE
Add support for Debain 7.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
   symlinks:
     stash: "#{source_dir}"
   repositories:
-    deploy: "git://github.com/mkrakowitzer/puppet-deploy"
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    deploy: "https://github.com/mkrakowitzer/puppet-deploy"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     repoforge: "https://github.com/Mylezeem/puppet-repoforge.git"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg/
 *.settings
 *.project
 Gemfile.lock
+.vagrant

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,8 @@ gem 'rspec-puppet'
 gem 'puppetlabs_spec_helper'
 gem 'puppet', puppetversion
 gem 'puppet-blacksmith'
+gem 'beaker'
+gem 'pry'
+gem 'serverspec', "~> 1.0"
+gem 'beaker-rspec', "~> 2.2.4",:require => false
+gem 'minitest', "~> 4"

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This is a puppet module to install stash
 
 Requirements
 ------------
-* Puppet 3.4+ tested (CentOS6/Ubuntu12)
-* Puppet PE tested 3.3.x (CentOS6)
+* Puppet 3.4+ tested (CentOS6/Ubuntu12/Debian7)
+* Puppet PE tested 3.3.2 (CentOS6)
 * dependency - mkrakowitzer/deploy '>= 0.0.3'
 * dependency - [puppetlabs repositories](https://docs.puppetlabs.com/guides/puppetlabs_package_repositories.html)
-* tested on RHEL6 / CentOS6 / Ubuntu 12.04.
+* tested on RHEL6 / CentOS6 / Ubuntu 12.04 / Debian 7
 
 Examples
 --------
@@ -146,6 +146,14 @@ ruby-1.9.3-p484/bin/ruby -S rspec spec/classes/stash_install_spec.rb --color
 Finished in 0.38159 seconds
 1 example, 0 failures
 ```
+
+Using [Beaker - Puppet Labs cloud enabled acceptance testing tool.](https://github.com/puppetlabs/beaker).
+
+run (Additional yak shaving may be required):
+
+BEAKER_set=ubuntu-server-12042-x64 bundle exec rake beaker
+BEAKER_set==debian-73-x64 bundle exec rake beaker
+BEAKER_set==centos-64-x64 bundle exec rake beaker
 
 License
 -------

--- a/Rakefile
+++ b/Rakefile
@@ -2,15 +2,21 @@ require 'rake'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'rspec/core/rake_task'
 require 'puppet_blacksmith/rake_tasks'
+require 'pp'
+require 'puppet-lint/tasks/puppet-lint'
+
+LINT_IGNORES = ['rvm']
 
 begin
   if Gem::Specification::find_by_name('puppet-lint')
     require 'puppet-lint/tasks/puppet-lint'
+    PuppetLint.configuration.fail_on_warnings = true,
     PuppetLint.configuration.send('disable_80chars')
-    PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "vendor/**/*.pp"]
-    task :default => [:rspec, :lint]
+    PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "vendor/**/*.pp", "pkg/**/**/*.pp"]
+    PuppetLint.configuration.log_format =
+        '%{path}:%{linenumber}:%{check}:%{KIND}:%{message}'
+
+    task :default => [:spec,]
   end
 rescue Gem::LoadError
 end
-
-

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -41,7 +41,7 @@ class stash::facts(
     }
   }
 
-  if $osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise/ {
+  if $::osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise/ {
     package { [ 'rubygem-json', 'ruby-json' ]:
       ensure => present,
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,7 +28,9 @@ class stash::install(
       if ! defined(Class['repoforge']) and $repoforge {
         class { 'repoforge':
           enabled     => [ 'extras', ],
-          includepkgs => { 'extras' => 'git,perl-Git' },
+          includepkgs => {
+            'extras' => 'git,perl-Git'
+          },
           before      => Package['git']
         } ~>
         exec { "${stash::product}_clean_yum_metadata":

--- a/manifests/post.pp
+++ b/manifests/post.pp
@@ -1,0 +1,15 @@
+# == Class: stash::post
+#
+class stash::post {
+
+  postgresql_psql { 'server.id':
+    command => "update app_property set prop_value = 'BPIA-X1C2-6W65-NU7D' where prop_key = 'server.id'",
+    db      => 'stash',
+  }
+
+  postgresql_psql { 'license':
+    command => "insert into app_property set prop_value = 'AAABHg0ODAoPeNptkMFqg0AQhu/7FAM9b8lqYjCwh0QtFdSEatoeetlup8lSXWV3Dc3bV2MgUHKYw8x8fPMzD2WvocQO2ByYv/LDlb+EKK7Am7E5idFKozqnWs1LJ+wR9rpWjXL4BXuLxn6sIDmJuhcjApmSqC2SyOBlEAuHfBTRWUjZgtxQ7kyPxI7KRyGdOuE0qSfD66AeKY/kQmmHWmiJyW+nzPnmZLPRuTUHoZWdrE/KWAfFpRE1bIT+AQrP7YBAhfKo27o9nK93r2mrc4eFaJBH2zxPXqJ0nZESzQlNGvPNLl3TdxZ5NHgLFrTYL2NSJgUfimbzxTIMfI9cRQOepfG9zf3kU4qibz7RbL8v7+SUkV1v5FFY/P+8PyQniXgwLQIUTkRzCztmVummuuq+d7MxDWdw4tICFQCQ/Fl6BEOoDCTXrrvODO2aOgWsqQ==X02ei' where prop_key = 'license';",
+    db      => 'stash',
+  }
+
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,18 +1,24 @@
 {
   "name": "mkrakowitzer-stash",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "mkrakowitzer",
   "summary": "Install atlassian stash",
   "license": "The MIT License (MIT)",
   "source": "https://github.com/mkrakowitzer/puppet-stash.git",
   "project_page": "https://github.com/mkrakowitzer/puppet-stash",
   "issues_url": "https://github.com/mkrakowitzer/puppet-stash/issues",
-  "description": "Atlassian Stash - All of this was stolen from mkrakowitzer-confluence and adapted for my selfish needs",
+  "description": "Atlassian Stash",
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6.0"
+        "6"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
       ]
     },
     {
@@ -20,32 +26,36 @@
       "operatingsystemrelease": [
         "12.04"
       ]
-    }
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
   ],
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0"
+      "version_requirement": ">= 4.0.0"
     },
     {
       "name": "mkrakowitzer/deploy",
-      "version_requirement": ">= 0.0.1"
+      "version_requirement": ">= 0.0.3"
     },
     {
       "name": "yguenane/repoforge",
       "version_requirement": ">= 0.2.0"
     },
-    {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0"
-    },
-    {
-      "name": "mkrakowitzer/deploy",
-      "version_requirement": ">= 0.0.1"
-    },
-    {
-      "name": "yguenane/repoforge",
-      "version_requirement": ">= 0.2.0"
-    }
   ]
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": "3.x"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": ">=3.4.0 <4.0.0"
+    }
+  ],
 }

--- a/spec/acceptance/default_parameters_spec.rb
+++ b/spec/acceptance/default_parameters_spec.rb
@@ -9,23 +9,6 @@ proxyurl = ENV['http_proxy'] if ENV['http_proxy']
 
 describe 'stash', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
 
-  it 'installs apt-key over proxy' do
-    if proxyurl
-      pp1 = <<-EOS
-        if $::operatingsystem == 'Ubuntu' {
-          apt_key { 'apt.postgresql.org':
-            ensure            => 'present',
-            id                => 'ACCC4CF8',
-            source            => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
-            keyserver_options => '--keyserver-options http-proxy=#{proxyurl}',
-          }
-        }
-      EOS
-      apply_manifest(pp1, :catch_failures => true)
-      apply_manifest(pp1, :catch_changes => true)
-    end
-  end
-
   it 'installs with defaults' do
     pp = <<-EOS
       $jh = $osfamily ? {
@@ -48,7 +31,8 @@ describe 'stash', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
         distribution => 'jdk',
       } ->
       class { 'stash':
-        downloadURL => 'http://10.43.230.24/',
+        downloadURL => 'http://10.0.0.12/',
+        version     => '3.2.4',
         javahome    => $jh,
       }
       class { 'stash::gc': }
@@ -74,8 +58,8 @@ describe 'stash', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
         default   => '/opt/java',
       }
       class { 'stash':
-        version     => '3.3.1',
-        downloadURL => 'http://10.43.230.24/',
+        version     => '3.3.0',
+        downloadURL => 'http://10.0.0.12/',
         javahome    => $jh,
       }
     EOS

--- a/spec/acceptance/default_parameters_spec.rb
+++ b/spec/acceptance/default_parameters_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper_acceptance'
+# These tests are designed to ensure that the module, when ran with defaults,
+# sets up everything correctly and allows us to connect to stash.
+
+proxyurl = ENV['http_proxy'] if ENV['http_proxy']
+
+# We add the sleeps everywhere to give stash enough
+# time to install/upgrade/run migration tasks/start/
+
+describe 'stash', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+
+  it 'installs apt-key over proxy' do
+    if proxyurl
+      pp1 = <<-EOS
+        if $::operatingsystem == 'Ubuntu' {
+          apt_key { 'apt.postgresql.org':
+            ensure            => 'present',
+            id                => 'ACCC4CF8',
+            source            => 'https://www.postgresql.org/media/keys/ACCC4CF8.asc',
+            keyserver_options => '--keyserver-options http-proxy=#{proxyurl}',
+          }
+        }
+      EOS
+      apply_manifest(pp1, :catch_failures => true)
+      apply_manifest(pp1, :catch_changes => true)
+    end
+  end
+
+  it 'installs with defaults' do
+    pp = <<-EOS
+      $jh = $osfamily ? {
+        'RedHat'  => '/usr/lib/jvm/java-1.7.0-openjdk.x86_64',
+        'Debian'  => '/usr/lib/jvm/java-7-openjdk-amd64',
+        default   => '/opt/java',
+      }
+      if versioncmp($::puppetversion,'3.6.1') >= 0 {
+        $allow_virtual_packages = hiera('allow_virtual_packages',false)
+        Package {
+          allow_virtual => $allow_virtual_packages,
+        }
+      }
+     class { 'postgresql::globals':
+        manage_package_repo => true,
+        version             => '9.3',
+      }->
+      class { 'postgresql::server': } ->
+      class { 'java':
+        distribution => 'jdk',
+      } ->
+      class { 'stash':
+        downloadURL => 'http://10.43.230.24/',
+        javahome    => $jh,
+      }
+      class { 'stash::gc': }
+      class { 'stash::facts': }
+      postgresql::server::db { 'stash':
+        user     => 'stash',
+        password => postgresql_password('stash', 'password'),
+      }
+    EOS
+    apply_manifest(pp, :catch_failures => true)
+    shell 'wget -q --tries=180 --retry-connrefused --read-timeout=10 localhost:7990', :acceptable_exit_codes => [0]
+    sleep 120
+    shell 'wget -q --tries=180 --retry-connrefused --read-timeout=10 localhost:7990', :acceptable_exit_codes => [0]
+    sleep 60
+    apply_manifest(pp, :catch_changes => true)
+  end
+
+  it 'upgrades with defaults' do
+    pp_update = <<-EOS
+      $jh = $osfamily ? {
+        'RedHat'  => '/usr/lib/jvm/java-1.7.0-openjdk.x86_64',
+        'Debian'  => '/usr/lib/jvm/java-7-openjdk-amd64',
+        default   => '/opt/java',
+      }
+      class { 'stash':
+        version     => '3.3.1',
+        downloadURL => 'http://10.43.230.24/',
+        javahome    => $jh,
+      }
+    EOS
+    sleep 180
+    shell 'wget -q --tries=180 --retry-connrefused --read-timeout=10 localhost:7990', :acceptable_exit_codes => [0]
+    apply_manifest(pp_update, :catch_failures => true)
+    shell 'wget -q --tries=180 --retry-connrefused --read-timeout=10 localhost:7990', :acceptable_exit_codes => [0]
+    sleep 180
+    shell 'wget -q --tries=180 --retry-connrefused --read-timeout=10 localhost:7990', :acceptable_exit_codes => [0]
+    apply_manifest(pp_update, :catch_changes => true)
+  end
+
+  describe process("java") do
+    it { should be_running }
+  end
+
+  describe port(7990) do
+    it { is_expected.to be_listening }
+  end
+
+  describe package('git') do
+    it { should be_installed }
+  end
+
+  describe service('stash') do
+    it { should be_enabled }
+  end
+
+  describe user('stash') do
+    it { should exist }
+  end
+
+  describe user('stash') do
+    it { should belong_to_group 'stash' }
+  end
+
+  describe user('stash') do
+    it { should have_login_shell '/bin/bash' }
+  end
+
+end

--- a/spec/acceptance/nodesets/centos-64-x64-pe.yml
+++ b/spec/acceptance/nodesets/centos-64-x64-pe.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  centos-64-x64:
+    roles:
+      - master
+      - database
+      - dashboard
+    platform: el-6-x86_64
+    box : centos-64-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  type: pe

--- a/spec/acceptance/nodesets/centos-64-x64.yml
+++ b/spec/acceptance/nodesets/centos-64-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  centos-64-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    box : centos-64-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  type: foss

--- a/spec/acceptance/nodesets/centos-65-x64.yml
+++ b/spec/acceptance/nodesets/centos-65-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  centos-65-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    box : centos-65-x64-vbox436-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-65-x64-virtualbox-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  type: foss

--- a/spec/acceptance/nodesets/debian-607-x64.yml
+++ b/spec/acceptance/nodesets/debian-607-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  debian-607-x64:
+    roles:
+      - master
+    platform: debian-6-amd64
+    box : debian-607-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/debian-607-x64-vbox4210-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  type: foss

--- a/spec/acceptance/nodesets/debian-70rc1-x64.yml
+++ b/spec/acceptance/nodesets/debian-70rc1-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  debian-70rc1-x64:
+    roles:
+      - master
+    platform: debian-7-amd64
+    box : debian-70rc1-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/debian-70rc1-x64-vbox4210-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  type: foss

--- a/spec/acceptance/nodesets/debian-73-x64.yml
+++ b/spec/acceptance/nodesets/debian-73-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  debian-73-x64.localhost:
+    roles:
+      - master
+    platform: debian-7-amd64
+    box : debian-73-x64-virtualbox-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/debian-73-x64-virtualbox-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  log_level: debug
+  type: foss

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  centos-64-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    box : centos-64-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  log_level: debug
+  type: foss

--- a/spec/acceptance/nodesets/fedora-18-x64.yml
+++ b/spec/acceptance/nodesets/fedora-18-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  fedora-18-x64:
+    roles:
+      - master
+    platform: fedora-18-x86_64
+    box : fedora-18-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/fedora-18-x64-vbox4210-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  type: foss

--- a/spec/acceptance/nodesets/sles-11-x64.yml
+++ b/spec/acceptance/nodesets/sles-11-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  sles-11-x64.local:
+    roles:
+      - master
+    platform: sles-11-x64
+    box : sles-11sp1-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/sles-11sp1-x64-vbox4210-nocm.box
+    hypervisor : vagrant
+CONFIG:
+    type: foss

--- a/spec/acceptance/nodesets/sles-11sp1-x64.yml
+++ b/spec/acceptance/nodesets/sles-11sp1-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  sles-11sp1-x64:
+    roles:
+      - master
+    platform: sles-11-x86_64
+    box : sles-11sp1-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/sles-11sp1-x64-vbox4210-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  type: foss

--- a/spec/acceptance/nodesets/ubuntu-server-10044-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-10044-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  ubuntu-server-10044-x64:
+    roles:
+      - master
+    platform: ubuntu-10.04-amd64
+    box : ubuntu-server-10044-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  type: foss

--- a/spec/acceptance/nodesets/ubuntu-server-12042-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-12042-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  ubuntu-server-12042-x64:
+    roles:
+      - master
+    platform: ubuntu-12.04-amd64
+    box : ubuntu-server-12042-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  type: foss

--- a/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  ubuntu-server-1404-x64:
+    roles:
+      - master
+    platform: ubuntu-14.04-amd64
+    box : puppetlabs/ubuntu-14.04-64-nocm
+    box_url : https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
+    hypervisor : vagrant
+CONFIG:
+  log_level   : debug
+  type: foss

--- a/spec/classes/stash_config_spec.rb
+++ b/spec/classes/stash_config_spec.rb
@@ -2,18 +2,25 @@ require 'spec_helper.rb'
 
 describe 'stash' do
 describe 'stash::config' do
-  context 'default params' do
+  context 'proxy params' do
     let(:params) {{
-      :version => '3.2.4',
-      :proxy   => {
+      :javahome => '/opt/java',
+      :version  => '3.2.4',
+      :proxy    => {
         'scheme'    => 'https',
         'proxyName' => 'stash.example.co.za',
         'proxyPort' => '443',
       },
     }}
-    it { should contain_file('/opt/stash/atlassian-stash-3.2.4/bin/setenv.sh')}
+    it { should contain_file('/opt/stash/atlassian-stash-3.2.4/bin/setenv.sh') \
+       .with_content(/JAVA_HOME=\/opt\/java/)
+    }
     it { should contain_file('/opt/stash/atlassian-stash-3.2.4/bin/user.sh')}
-    it { should contain_file('/opt/stash/atlassian-stash-3.2.4/conf/server.xml').with_content(/stash\.example\.co\.za/)}
+    it { should contain_file('/opt/stash/atlassian-stash-3.2.4/conf/server.xml') \
+      .with_content(/proxyName = \'stash\.example\.co\.za\'/)
+      .with_content(/proxyPort = \'443\'/)
+      .with_content(/scheme = \'https\'/)
+    }
     it { should contain_file('/home/stash/shared/stash-config.properties')}
   end
 end

--- a/spec/classes/stash_init_spec.rb
+++ b/spec/classes/stash_init_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper.rb'
+
+describe 'stash' do
+  context 'prepare for upgrade of stash' do
+    let(:params) {{ :version => '3.3.3' }}
+    let(:facts) {{ :stash_version => "2.10.1" }}
+    it {
+      should contain_exec('service stash stop && sleep 15').with({
+         :command => 'service stash stop && sleep 15',
+      })
+      should contain_exec('rm -f /home/stash/stash-config.properties').with({
+         :command => 'rm -f /home/stash/stash-config.properties',
+      })
+    }
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -32,8 +32,8 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
     on host, "mkdir -p #{host['distmoduledir']}"
     # Set puppet proxy, TODO: This is still hard coded
     if proxyurl
-      on host, "echo \"[user]\nhttp_proxy_host = 10.203.72.21\" >> #{host['puppetpath']}/puppet.conf"
-      on host, "echo \"http_proxy_port = 7070\" >> #{host['puppetpath']}/puppet.conf"
+      on host, "echo \"[user]\nhttp_proxy_host = 10.0.0.12\" >> #{host['puppetpath']}/puppet.conf"
+      on host, "echo \"http_proxy_port = 3128\" >> #{host['puppetpath']}/puppet.conf"
       on host, "sed -i '/templatedir/d' #{host['puppetpath']}/puppet.conf"
     end
   end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -32,9 +32,9 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
     on host, "mkdir -p #{host['distmoduledir']}"
     # Set puppet proxy, TODO: This is still hard coded
     if proxyurl
-      on host, "echo \"[main]\nhttp_proxy_host = 10.203.72.21\" >> #{host['distmoduledir']}/puppet.conf"
-      on host, "echo \"http_proxy_port = 7070\" >> #{host['distmoduledir']}/puppet.conf"
-      on host, "sed -i '/templatedir/d' #{host['distmoduledir']}/puppet.conf"
+      on host, "echo \"[user]\nhttp_proxy_host = 10.203.72.21\" >> #{host['puppetpath']}/puppet.conf"
+      on host, "echo \"http_proxy_port = 7070\" >> #{host['puppetpath']}/puppet.conf"
+      on host, "sed -i '/templatedir/d' #{host['puppetpath']}/puppet.conf"
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,74 @@
+require 'beaker-rspec/spec_helper'
+require 'beaker-rspec/helpers/serverspec'
+
+proxyurl = ENV['http_proxy'] if ENV['http_proxy']
+
+unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
+  hosts.each do |host|
+    if proxyurl
+      # Set proxy for everything
+      on host, "echo 'proxy = #{proxyurl}' >> /root/.curlrc; exit 0"
+      on host, "echo \"---\nhttp-proxy: #{proxyurl}\" >> /root/.gemrc"
+      on host, "echo 'export http_proxy=#{proxyurl}' >> /root/.bashrc"
+      on host, "echo 'export https_proxy=#{proxyurl}' >> /root/.bashrc"
+      on host, 'echo "use_proxy = off" >> /etc/wgetrc'
+      # Allow proxy to cache better
+      on host, 'rm -f /etc/yum/pluginconf.d/fastestmirror.conf; exit 0'
+      on host, "sed -i 's/^mirrorlist=/#mirrorlist=/g'  /etc/yum.repos.d/*; exit 0"
+      on host, "sed -i 's/#baseurl=/baseurl=/g' /etc/yum.repos.d/*; exit 0"
+    end
+    # This will install the latest available package on el and deb based
+    # systems fail on windows and osx, and install via gem on other *nixes
+    foss_opts = { :default_action => 'gem_install' }
+    if default.is_pe?; then
+      # TODO: fetch_http_dir hangs
+      # fetch_http_dir('http://10.43.230.24/el-6-x86_64','/opt/enterprise/dists/LATEST')
+      # TODO: install_pe doesnt work nativy, needs some work on my part
+      on host, 'wget -nv -P /opt/enterprise/dists/LATEST --reject "index.html*","*.gif" --cut-dirs=1 -np -nH --no-check-certificate -r http://10.43.230.24/el-6-x86_64/'
+      on host, ' yum localinstall -y /opt/enterprise/dists/LATEST/*.rpm'
+    else
+      install_puppet( foss_opts )
+    end
+    on host, "mkdir -p #{host['distmoduledir']}"
+    # Set puppet proxy, TODO: This is still hard coded
+    if proxyurl
+      on host, "echo \"[main]\nhttp_proxy_host = 10.203.72.21\" >> #{host['distmoduledir']}/puppet.conf"
+      on host, "echo \"http_proxy_port = 7070\" >> #{host['distmoduledir']}/puppet.conf"
+      on host, "sed -i '/templatedir/d' #{host['distmoduledir']}/puppet.conf"
+    end
+  end
+end
+
+UNSUPPORTED_PLATFORMS = ['AIX','windows','Solaris']
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module
+    puppet_module_install(
+      :source => proj_root,
+      :module_name => 'stash',
+      :ignore_list => [ 'spec/fixtures/*', '.git/*', '.vagrant/*' ],
+    )
+    hosts.each do |host|
+      on host, "/bin/touch #{default['puppetpath']}/hiera.yaml"
+      on host, 'chmod 755 /root'
+      if fact('osfamily') == 'Debian'
+        on host, "echo \"en_US ISO-8859-1\nen_NG.UTF-8 UTF-8\nen_US.UTF-8 UTF-8\n\" > /etc/locale.gen"
+        on host, '/usr/sbin/locale-gen'
+        on host, '/usr/sbin/update-locale'
+      end
+      on host, puppet('module','install','puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module','install','puppetlabs-postgresql'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module','install','yguenane-repoforge'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module','install','mkrakowitzer-deploy'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module','install','puppetlabs-java'), { :acceptable_exit_codes => [0,1] }
+    end
+  end
+end


### PR DESCRIPTION
Add beaker tests for Puppet opensource: Centos 6, Ubuntu 12.04, Debian 7
Add beaker tests for Puppet Enterprise: Centos 6

 Debian support Issue #24 resolved.
