### PR TITLE
(MODULES-1467) refactor params.pp for for puppetlabs approved

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,24 +3,28 @@
 # Defines default values for stash module
 #
 class stash::params {
-  case "${::osfamily}${::operatingsystemmajrelease}" {
-    /RedHat7/: {
-      $json_packages           = 'rubygem-json'
-      $service_file_location   = '/usr/lib/systemd/system/stash.service'
-      $service_file_template   = 'stash/stash.service.erb'
-      $service_lockfile        = '/var/lock/subsys/stash'
+  case $::osfamily {
+    /RedHat/: {
+      if $::operatingsystemmajrelease == '7' {
+        $json_packages           = 'rubygem-json'
+        $service_file_location   = '/usr/lib/systemd/system/stash.service'
+        $service_file_template   = 'stash/stash.service.erb'
+        $service_lockfile        = '/var/lock/subsys/stash'
+      } elsif $::operatingsystemmajrelease == '6' {
+        $json_packages           = [ 'rubygem-json', 'ruby-json' ]
+        $service_file_location   = '/etc/init.d/stash'
+        $service_file_template   = 'stash/stash.initscript.redhat.erb'
+        $service_lockfile        = '/var/lock/subsys/stash'
+      } else {
+        fail("${::operatingsystem} ${::operatingsystemmajrelease} not supported")
+      }
     } /Debian/: {
       $json_packages           = [ 'rubygem-json', 'ruby-json' ]
       $service_file_location   = '/etc/init.d/stash'
       $service_file_template   = 'stash/stash.initscript.debian.erb'
       $service_lockfile        = '/var/lock/stash'
-    } /RedHat6/: {
-      $json_packages           = [ 'rubygem-json', 'ruby-json' ]
-      $service_file_location   = '/etc/init.d/stash'
-      $service_file_template   = 'stash/stash.initscript.redhat.erb'
-      $service_lockfile        = '/var/lock/subsys/stash'
     } default: {
-      fail("${::operatingsystem} ${::operatingsystemmajrelease} is not supported")
+      fail("${::operatingsystem} ${::operatingsystemmajrelease} not supported")
     }
   }
 }


### PR DESCRIPTION
Your pattern in `params.pp`
(https://github.com/mkrakowitzer/puppet-stash/blob/master/manifests/params.pp#L6)
is a little unusual, it might be better to update it to be something
like `case "${::osfamily}"` and then have another case (or if/else)
under `RedHat`.
