### PR TITLE
Refactor spec tests to make use of rspec-puppet-facts gem

### DIFF
--- a/spec/classes/stash_backup_deploy_spec.rb
+++ b/spec/classes/stash_backup_deploy_spec.rb
@@ -1,36 +1,46 @@
 require 'spec_helper.rb'
 
 describe 'stash' do
-  describe 'stash::backup' do
-    context 'install stash backup client  with deploy module' do
-      it { should contain_group('stash') }
-      it { should contain_user('stash').with_shell('/bin/bash') }
-      it 'should deploy stash backup client 1.6.0 from tar.gz' do
-        should contain_staging__file("stash-backup-distribution-1.6.0.tar.gz")
-      end
-      it 'should manage the stash-backup directory' do
-        should contain_file('/opt/stash-backup').with({
-          'ensure' => 'directory',
-          'owner'  => 'stash',
-          'group'  => 'stash'
-          })
-      end
-      it 'should manage the stash-backup archives directory' do
-        should contain_file('/opt/stash-backup/archives').with({
-          'ensure' => 'directory',
-          'owner'  => 'stash',
-          'group'  => 'stash'
-          })
-      end
-      it 'should manage the backup cron job' do
-        should contain_cron('Backup Stash').with({
-          'ensure'  => 'present',
-          'command' => '/usr/bin/java -Dstash.password="password" -Dstash.user="admin" -Dstash.baseUrl="http://localhost:7990" -Dstash.home=/home/stash -Dbackup.home=/opt/stash-backup/archives -jar /opt/stash-backup/stash-backup-client-1.6.0/stash-backup-client.jar',
-          'user'    => 'stash',
-          'hour'    => '5',
-          'minute'  => '0',
-          })
+describe 'stash::backup' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os} #{facts}" do
+        let(:facts) do
+          facts
+        end
+
+        context 'install stash backup client  with deploy module' do
+          it { should contain_group('stash') }
+          it { should contain_user('stash').with_shell('/bin/bash') }
+          it 'should deploy stash backup client 1.6.0 from tar.gz' do
+            should contain_staging__file("stash-backup-distribution-1.6.0.tar.gz")
+          end
+          it 'should manage the stash-backup directory' do
+            should contain_file('/opt/stash-backup').with({
+              'ensure' => 'directory',
+              'owner'  => 'stash',
+              'group'  => 'stash'
+              })
+          end
+          it 'should manage the stash-backup archives directory' do
+            should contain_file('/opt/stash-backup/archives').with({
+              'ensure' => 'directory',
+              'owner'  => 'stash',
+              'group'  => 'stash'
+              })
+          end
+          it 'should manage the backup cron job' do
+            should contain_cron('Backup Stash').with({
+              'ensure'  => 'present',
+              'command' => '/usr/bin/java -Dstash.password="password" -Dstash.user="admin" -Dstash.baseUrl="http://localhost:7990" -Dstash.home=/home/stash -Dbackup.home=/opt/stash-backup/archives -jar /opt/stash-backup/stash-backup-client-1.6.0/stash-backup-client.jar',
+              'user'    => 'stash',
+              'hour'    => '5',
+              'minute'  => '0',
+              })
+          end
+        end
       end
     end
   end
+end
 end

--- a/spec/classes/stash_backup_staging_spec.rb
+++ b/spec/classes/stash_backup_staging_spec.rb
@@ -1,36 +1,46 @@
 require 'spec_helper.rb'
 
 describe 'stash' do
-  describe 'stash::backup' do
-    context 'install stash backup client  with staging module' do
-      it { should contain_group('stash') }
-      it { should contain_user('stash').with_shell('/bin/bash') }
-      it 'should deploy stash backup client 1.6.0 from tar.gz' do
-        should contain_staging__file("stash-backup-distribution-1.6.0.tar.gz")
-      end
-      it 'should manage the stash-backup directory' do
-        should contain_file('/opt/stash-backup').with({
-          'ensure' => 'directory',
-          'owner'  => 'stash',
-          'group'  => 'stash'
-          })
-      end
-      it 'should manage the stash-backup archives directory' do
-        should contain_file('/opt/stash-backup/archives').with({
-          'ensure' => 'directory',
-          'owner'  => 'stash',
-          'group'  => 'stash'
-          })
-      end
-      it 'should manage the backup cron job' do
-        should contain_cron('Backup Stash').with({
-          'ensure'  => 'present',
-          'command' => '/usr/bin/java -Dstash.password="password" -Dstash.user="admin" -Dstash.baseUrl="http://localhost:7990" -Dstash.home=/home/stash -Dbackup.home=/opt/stash-backup/archives -jar /opt/stash-backup/stash-backup-client-1.6.0/stash-backup-client.jar',
-          'user'    => 'stash',
-          'hour'    => '5',
-          'minute'  => '0',
-          })
+describe 'stash::backup' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os} #{facts}" do
+        let(:facts) do
+          facts
+        end
+
+        context 'install stash backup client  with staging module' do
+          it { should contain_group('stash') }
+          it { should contain_user('stash').with_shell('/bin/bash') }
+          it 'should deploy stash backup client 1.6.0 from tar.gz' do
+            should contain_staging__file("stash-backup-distribution-1.6.0.tar.gz")
+          end
+          it 'should manage the stash-backup directory' do
+            should contain_file('/opt/stash-backup').with({
+              'ensure' => 'directory',
+              'owner'  => 'stash',
+              'group'  => 'stash'
+              })
+          end
+          it 'should manage the stash-backup archives directory' do
+            should contain_file('/opt/stash-backup/archives').with({
+              'ensure' => 'directory',
+              'owner'  => 'stash',
+              'group'  => 'stash'
+              })
+          end
+          it 'should manage the backup cron job' do
+            should contain_cron('Backup Stash').with({
+              'ensure'  => 'present',
+              'command' => '/usr/bin/java -Dstash.password="password" -Dstash.user="admin" -Dstash.baseUrl="http://localhost:7990" -Dstash.home=/home/stash -Dbackup.home=/opt/stash-backup/archives -jar /opt/stash-backup/stash-backup-client-1.6.0/stash-backup-client.jar',
+              'user'    => 'stash',
+              'hour'    => '5',
+              'minute'  => '0',
+              })
+          end
+        end
       end
     end
   end
+end
 end

--- a/spec/classes/stash_config_spec.rb
+++ b/spec/classes/stash_config_spec.rb
@@ -1,85 +1,103 @@
-require 'spec_helper.rb'
+require 'spec_helper'
 
 describe 'stash' do
-  describe 'stash::config' do
-    context 'default params' do
-      let(:params) {{
-        :javahome  => '/opt/java',
-        :version   => '3.2.4',
-      }}
-      it { should contain_file('/opt/stash/atlassian-stash-3.2.4/bin/setenv.sh') \
-         .with_content(/JAVA_HOME=\/opt\/java/)
-      }
-      it { should contain_file('/opt/stash/atlassian-stash-3.2.4/bin/user.sh')}
-      it { should contain_file('/opt/stash/atlassian-stash-3.2.4/conf/server.xml')}
-      it { should contain_file('/home/stash/shared/stash-config.properties')}
-    end
-    context 'proxy settings ' do
-      let(:params) {{
-        :version     => '3.4.0',
-        :proxy   => {
-          'scheme'    => 'https',
-          'proxyName' => 'stash.example.co.za',
-          'proxyPort' => '443',
-        },
-      }}
-      it do
-        should contain_file('/opt/stash/atlassian-stash-3.4.0/conf/server.xml') \
-          .with_content(/proxyName = \'stash\.example\.co\.za\'/)
-          .with_content(/proxyPort = \'443\'/)
-          .with_content(/scheme = \'https\'/)
-          .with_content(/path=""/)
-      end
-    end
-    context 'jvm_xms => 1G' do
-      let(:params) {{
-        :version => '3.4.0',
-        :jvm_xms => '1G',
-      }}
-      it do
-        should contain_file('/opt/stash/atlassian-stash-3.4.0/bin/setenv.sh')
-          .with_content(/^JVM_MINIMUM_MEMORY="1G"/)
-      end
-    end
-    context 'jvm_xmx => 4G' do
-      let(:params) {{
-        :version => '3.4.0',
-        :jvm_xmx => '4G',
-      }}
-      it do
-        should contain_file('/opt/stash/atlassian-stash-3.4.0/bin/setenv.sh')
-          .with_content(/^JVM_MAXIMUM_MEMORY="4G"/)
-      end
-    end
-    context 'jvm_permgen => 384m' do
-      let(:params) {{
-        :version     => '3.4.0',
-        :jvm_permgen => '384m',
-      }}
-      it do
-        should contain_file('/opt/stash/atlassian-stash-3.4.0/bin/setenv.sh')
-          .with_content(/^STASH_MAX_PERM_SIZE=384m/)
-      end
-    end
-    context 'java_opts => "-Dhttp.proxyHost=proxy.example.co.za -Dhttp.proxyPort=8080"' do
-      let(:params) {{
-        :version     => '3.4.0',
-        :java_opts   => '-Dhttp.proxyHost=proxy.example.co.za -Dhttp.proxyPort=8080',
-      }}
-      it do
-        should contain_file('/opt/stash/atlassian-stash-3.4.0/bin/setenv.sh')
-          .with_content(/JAVA_OPTS="-Dhttp\.proxyHost=proxy\.example\.co\.za -Dhttp\.proxyPort=8080/)
-      end
-    end
-    context 'context_path => "stash"' do
-      let(:params) {{
-        :version      => '3.4.0',
-        :context_path => '/stash',
-      }}
-      it do
-        should contain_file('/opt/stash/atlassian-stash-3.4.0/conf/server.xml')
-          .with_content(/path="\/stash"/)
+describe 'stash::config' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os} #{facts}" do
+        let(:facts) do
+          facts
+        end
+
+        context 'default params' do
+          let(:params) do
+            {
+              :javahome  => '/opt/java',
+              :version   => '3.6.1',
+           }
+          end
+          it do should contain_file('/opt/stash/atlassian-stash-3.6.1/bin/setenv.sh') \
+             .with_content(/JAVA_HOME=\/opt\/java/)
+          end
+          it { should contain_file('/opt/stash/atlassian-stash-3.6.1/bin/user.sh')}
+          it { should contain_file('/opt/stash/atlassian-stash-3.6.1/conf/server.xml')}
+          it { should contain_file('/home/stash/shared/stash-config.properties')}
+        end
+
+        context 'proxy settings ' do
+          let(:params) {{
+            :version     => '3.6.1',
+            :proxy   => {
+              'scheme'    => 'https',
+              'proxyName' => 'stash.example.co.za',
+              'proxyPort' => '443',
+            },
+          }}
+          it do
+            should contain_file('/opt/stash/atlassian-stash-3.6.1/conf/server.xml') \
+              .with_content(/proxyName = \'stash\.example\.co\.za\'/)
+              .with_content(/proxyPort = \'443\'/)
+              .with_content(/scheme = \'https\'/)
+              .with_content(/path=""/)
+          end
+        end
+
+        context 'jvm_xms => 1G' do
+          let(:params) {{
+            :version => '3.6.1',
+            :jvm_xms => '1G',
+          }}
+          it do
+            should contain_file('/opt/stash/atlassian-stash-3.6.1/bin/setenv.sh')
+              .with_content(/^JVM_MINIMUM_MEMORY="1G"/)
+          end
+        end
+
+        context 'jvm_xmx => 4G' do
+          let(:params) {{
+            :version => '3.6.1',
+            :jvm_xmx => '4G',
+          }}
+          it do
+            should contain_file('/opt/stash/atlassian-stash-3.6.1/bin/setenv.sh')
+              .with_content(/^JVM_MAXIMUM_MEMORY="4G"/)
+          end
+        end
+
+        context 'jvm_permgen => 384m' do
+          let(:params) {{
+            :version     => '3.6.1',
+            :jvm_permgen => '384m',
+          }}
+          it do
+            should contain_file('/opt/stash/atlassian-stash-3.6.1/bin/setenv.sh')
+              .with_content(/^STASH_MAX_PERM_SIZE=384m/)
+          end
+        end
+
+        context 'java_opts => "-Dhttp.proxyHost=proxy.example.co.za -Dhttp.proxyPort=8080"' do
+          let(:params) {{
+            :version     => '3.6.1',
+            :java_opts   => '-Dhttp.proxyHost=proxy.example.co.za -Dhttp.proxyPort=8080',
+          }}
+          it do
+            should contain_file('/opt/stash/atlassian-stash-3.6.1/bin/setenv.sh')
+              .with_content(/JAVA_OPTS="-Dhttp\.proxyHost=proxy\.example\.co\.za -Dhttp\.proxyPort=8080/)
+          end
+        end
+
+        context 'context_path => "stash"' do
+          let(:params) {{
+            :version      => '3.6.1',
+            :context_path => '/stash',
+          }}
+          it do
+            should contain_file('/opt/stash/atlassian-stash-3.6.1/conf/server.xml')
+              .with_content(/path="\/stash"/)
+          end
+        end
       end
     end
   end
+end
 end

--- a/spec/classes/stash_facts_spec.rb
+++ b/spec/classes/stash_facts_spec.rb
@@ -1,36 +1,49 @@
-require 'spec_helper.rb'
+require 'spec_helper'
+
 describe 'stash::facts', :type => :class  do
-  regexp_pe = /^#\!\/opt\/puppet\/bin\/ruby$/
-  regexp_oss = /^#\!\/usr\/bin\/env ruby$/
-  pe_external_fact_file = '/etc/puppetlabs/facter/facts.d/stash_facts.rb'
-  external_fact_file = '/etc/facter/facts.d/stash_facts.rb'
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os} #{facts}" do
+        let(:facts) do
+          facts
+        end
+        regexp_pe = /^#\!\/opt\/puppet\/bin\/ruby$/
+        regexp_oss = /^#\!\/usr\/bin\/env ruby$/
+        pe_external_fact_file = '/etc/puppetlabs/facter/facts.d/stash_facts.rb'
+        external_fact_file = '/etc/facter/facts.d/stash_facts.rb'
 
-  it { should contain_file(external_fact_file) }
+        it { should contain_file(external_fact_file) }
 
-  # Test puppet enterprise shebang generated correctly
-  context 'with puppet enterprise' do
-    let(:facts) { {:puppetversion => "3.4.3 (Puppet Enterprise 3.2.1)"} }
-    it do
-      should contain_file(pe_external_fact_file) \
-        .with_content(regexp_pe)
-    end
-  end
-  # Test puppet oss shebang generated correctly
-  context 'with puppet oss' do
-    let(:facts) { {:puppetversion => "all other versions"} }
-    it do
-      should contain_file(external_fact_file) \
-        .with_content(regexp_oss)
-        .with_content(/7990\/rest\/api\//)
-    end
-  end
-  context 'with context' do
-    let(:params) {{
-      :context_path => '/stash',
-    }}
-    it do
-      should contain_file(external_fact_file) \
-        .with_content(/7990\/stash\/rest\/api\//)
+        # Test puppet enterprise shebang generated correctly
+        context 'with puppet enterprise' do
+          let(:facts) do
+            facts.merge({ :puppetversion => "3.4.3 (Puppet Enterprise 3.2.1)"})
+          end
+          it do
+            should contain_file(pe_external_fact_file) \
+              .with_content(regexp_pe)
+          end
+        end
+
+        ## Test puppet oss shebang generated correctly
+        context 'with puppet oss' do
+          it do
+            should contain_file(external_fact_file) \
+              .with_content(regexp_oss)
+              .with_content(/7990\/rest\/api\//)
+          end
+        end
+
+        context 'with context' do
+          let(:params) {{
+            :context_path => '/stash',
+          }}
+          it do
+            should contain_file(external_fact_file) \
+              .with_content(/7990\/stash\/rest\/api\//)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/classes/stash_init_spec.rb
+++ b/spec/classes/stash_init_spec.rb
@@ -1,16 +1,40 @@
-require 'spec_helper.rb'
+require 'spec_helper'
 
-describe 'stash', :type => :class do
-  context 'prepare for upgrade of stash' do
-    let(:params) {{ :version => '3.3.3' }}
-    let(:facts) {{ :stash_version => "2.10.1" }}
-    it {
-      should contain_exec('service stash stop && sleep 15').with({
-         :command => 'service stash stop && sleep 15',
-      })
-      should contain_exec('rm -f /home/stash/stash-config.properties').with({
-         :command => 'rm -f /home/stash/stash-config.properties',
-      })
-    }
+describe 'stash' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os} #{facts}" do
+        let(:facts) do
+          facts
+        end
+        context "test class without any parameters" do
+          let(:params) {{ }}
+
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to contain_class('stash') }
+          it { is_expected.to contain_class('stash::params') }
+          it { is_expected.to contain_class('stash::install').that_comes_before('stash::config') }
+          it { is_expected.to contain_class('stash::config') }
+          it { is_expected.to contain_class('stash::backup') }
+          it { is_expected.to contain_class('stash::service').that_subscribes_to('stash::config') }
+          it { is_expected.to contain_class('staging') }
+
+          it { is_expected.to contain_service('stash') }
+        end
+      end
+    end
+  end
+  context 'unsupported operating system' do
+    describe 'test class without any parameters on Solaris/Nexenta' do
+      let(:facts) {{
+        :osfamily        => 'Solaris',
+        :operatingsystem => 'Nexenta',
+	:operatingsystemmajrelease => '7',
+      }}
+
+      it { expect { is_expected.to contain_service('stash') }.to raise_error(Puppet::Error, /Nexenta 7 not supported/) }
+    end
   end
 end
+

--- a/spec/classes/stash_install_deploy_spec.rb
+++ b/spec/classes/stash_install_deploy_spec.rb
@@ -1,91 +1,100 @@
 require 'spec_helper.rb'
 
 describe 'stash' do
-  describe 'stash::install' do
-    context 'install stash with deploy module' do
-      let(:params) {{
-        :version => '2.12.0',
-        :staging_or_deploy => 'deploy',
-      }}
-      it 'should install, but not upgrade, git' do
-        should contain_package('git').with_ensure('installed')
-      end
-      it { should contain_group('stash') }
-      it { should contain_user('stash').with_shell('/bin/bash') }
-      it 'should deploy stash 2.12.0 from tar.gz' do
-        should contain_deploy__file("atlassian-stash-2.12.0.tar.gz")
-      end
-      it 'should manage the stash home directory' do
-        should contain_file('/home/stash').with({
-          'ensure' => 'directory',
-          'owner' => 'stash',
-          'group' => 'stash'
-          })
-      end
-    end
-  
-    context 'overwriting params' do
-      let(:params) {{
-        :version => '2.12.0',
-        :product => 'stash',
-        :format => 'tar.gz',
-        :installdir => '/opt/stash',
-        :homedir => '/random/homedir',
-        :user  => 'foo',
-        :group => 'bar',
-        :uid   => 333,
-        :gid   => 444,
-        :downloadURL => 'http://downloads.atlassian.com/',
-        :git_version => 'installed',
-        :staging_or_deploy => 'deploy',
-      }}
-      it { should contain_user('foo').with({
-          'home'  => '/random/homedir',
-          'shell' => '/bin/bash',
-          'uid'   => 333,
-          'gid'   => 444
-        }) }
-      it { should contain_group('bar') }
-  
-      it 'should deploy stash 2.12.0 from tar.gz' do
-        should contain_deploy__file("atlassian-stash-2.12.0.tar.gz").with({
-          'url' => 'http://downloads.atlassian.com/',
-          'owner' => 'foo',
-          'group' => 'bar'
-          })
-      end
-  
-      it 'should manage the stash home directory' do
-        should contain_file('/random/homedir').with({
-          'ensure' => 'directory',
-          'owner' => 'foo',
-          'group' => 'bar'
-          })
-      end
-    end
-  
-    context 'specify git version' do
-      let(:params) {{
-        :version => '2.12.0',
-        :git_version => '1.7.12',
-        :staging_or_deploy => 'deploy',
-        }}
-  
-      it 'should ensure a specific version of git is installed' do
-        should contain_package('git').with_ensure('1.7.12')
-      end
-      it { should contain_group('stash') }
-      it { should contain_user('stash').with_shell('/bin/bash') }
-      it 'should deploy stash 2.12.0 from tar.gz' do
-        should contain_deploy__file("atlassian-stash-2.12.0.tar.gz")
-      end
-      it 'should manage the stash home directory' do
-        should contain_file('/home/stash').with({
-          'ensure' => 'directory',
-          'owner' => 'stash',
-          'group' => 'stash'
-          })
+describe 'stash::install' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os} #{facts}" do
+        let(:facts) do
+          facts
+        end
+
+        context 'install stash with deploy module' do
+          let(:params) {{
+            :version => '3.6.1',
+            :staging_or_deploy => 'deploy',
+          }}
+          it 'should install, but not upgrade, git' do
+            should contain_package('git').with_ensure('installed')
+          end
+          it { should contain_group('stash') }
+          it { should contain_user('stash').with_shell('/bin/bash') }
+          it 'should deploy stash 3.6.1 from tar.gz' do
+            should contain_deploy__file("atlassian-stash-3.6.1.tar.gz")
+          end
+          it 'should manage the stash home directory' do
+            should contain_file('/home/stash').with({
+              'ensure' => 'directory',
+              'owner' => 'stash',
+              'group' => 'stash'
+              })
+          end
+        end
+
+        context 'overwriting params' do
+          let(:params) {{
+            :version => '3.6.1',
+            :product => 'stash',
+            :format => 'tar.gz',
+            :installdir => '/opt/stash',
+            :homedir => '/random/homedir',
+            :user  => 'foo',
+            :group => 'bar',
+            :uid   => 333,
+            :gid   => 444,
+            :downloadURL => 'http://downloads.atlassian.com/',
+            :git_version => 'installed',
+            :staging_or_deploy => 'deploy',
+          }}
+          it do should contain_user('foo').with({
+              'home'  => '/random/homedir',
+              'shell' => '/bin/bash',
+              'uid'   => 333,
+              'gid'   => 444
+            })
+          end
+          it { should contain_group('bar') }
+          it 'should deploy stash 3.6.1 from tar.gz' do
+            should contain_deploy__file("atlassian-stash-3.6.1.tar.gz").with({
+              'url' => 'http://downloads.atlassian.com/',
+              'owner' => 'foo',
+              'group' => 'bar'
+            })
+          end
+          it 'should manage the stash home directory' do
+            should contain_file('/random/homedir').with({
+              'ensure' => 'directory',
+              'owner' => 'foo',
+              'group' => 'bar'
+              })
+          end
+        end
+
+        context 'specify git version' do
+          let(:params) {{
+            :version => '3.6.1',
+            :git_version => '1.7.12',
+            :staging_or_deploy => 'deploy',
+            }}
+      
+          it 'should ensure a specific version of git is installed' do
+            should contain_package('git').with_ensure('1.7.12')
+          end
+          it { should contain_group('stash') }
+          it { should contain_user('stash').with_shell('/bin/bash') }
+          it 'should deploy stash 3.6.1 from tar.gz' do
+            should contain_deploy__file("atlassian-stash-3.6.1.tar.gz")
+          end
+          it 'should manage the stash home directory' do
+            should contain_file('/home/stash').with({
+              'ensure' => 'directory',
+              'owner' => 'stash',
+              'group' => 'stash'
+              })
+          end
+        end
       end
     end
   end
+end
 end

--- a/spec/classes/stash_install_staging_spec.rb
+++ b/spec/classes/stash_install_staging_spec.rb
@@ -1,88 +1,98 @@
-require 'spec_helper.rb'
+require 'spec_helper'
 
 describe 'stash' do
-  describe 'stash::install' do
-    context 'install stash with deploy module' do
-      let(:params) {{
-        :version => '2.12.0',
-      }}
-      it 'should install, but not upgrade, git' do
-        should contain_package('git').with_ensure('installed')
-      end
-      it { should contain_group('stash') }
-      it { should contain_user('stash').with_shell('/bin/bash') }
-      it 'should deploy stash 2.12.0 from tar.gz' do
-        should contain_staging__file("atlassian-stash-2.12.0.tar.gz").with({
-          'source' => 'http://www.atlassian.com/software/stash/downloads/binary//atlassian-stash-2.12.0.tar.gz',
-          })
-      end
-      it 'should manage the stash home directory' do
-        should contain_file('/home/stash').with({
-          'ensure' => 'directory',
-          'owner' => 'stash',
-          'group' => 'stash'
-          })
-      end
-    end
-  
-    context 'overwriting params' do
-      let(:params) {{
-        :version => '2.12.0',
-        :product => 'stash',
-        :format => 'tar.gz',
-        :installdir => '/opt/stash',
-        :homedir => '/random/homedir',
-        :user  => 'foo',
-        :group => 'bar',
-        :uid   => 333,
-        :gid   => 444,
-        :downloadURL => 'http://downloads.atlassian.com/',
-        :git_version => 'installed',
-      }}
-      it { should contain_user('foo').with({
-          'home'  => '/random/homedir',
-          'shell' => '/bin/bash',
-          'uid'   => 333,
-          'gid'   => 444
-        }) }
-      it { should contain_group('bar') }
-      it 'should deploy stash 2.12.0 from tar.gz' do
-        should contain_staging__file("atlassian-stash-2.12.0.tar.gz").with({
-          'source' => 'http://downloads.atlassian.com//atlassian-stash-2.12.0.tar.gz',
-          })
-      end 
-
-      it 'should manage the stash home directory' do
-        should contain_file('/random/homedir').with({
-          'ensure' => 'directory',
-          'owner' => 'foo',
-          'group' => 'bar'
-          })
-      end
-    end
-  
-    context 'specify git version' do
-      let(:params) {{
-        :version => '2.12.0',
-        :git_version => '1.7.12',
-        :staging_or_deploy => 'deploy',
-        }}
-  
-      it 'should ensure a specific version of git is installed' do
-        should contain_package('git').with_ensure('1.7.12')
-      end
-      it { should contain_group('stash') }
-      it { should contain_user('stash').with_shell('/bin/bash') }
-      it 'should deploy stash 2.12.0 from tar.gz' do
-        should contain_deploy__file("atlassian-stash-2.12.0.tar.gz")
-      end
-      it 'should manage the stash home directory' do
-        should contain_file('/home/stash').with({
-          'ensure' => 'directory',
-          'owner' => 'stash',
-          'group' => 'stash'
-          })
+describe 'stash::install' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os} #{facts}" do
+        let(:facts) do
+          facts
+        end
+        context 'install stash with deploy module' do
+          let(:params) {{
+            :version => '3.6.1',
+          }}
+          it 'should install, but not upgrade, git' do
+            should contain_package('git').with_ensure('installed')
+          end
+          it { should contain_group('stash') }
+          it { should contain_user('stash').with_shell('/bin/bash') }
+          it 'should deploy stash from tar.gz' do
+	    str = "atlassian-stash-3.6.1.tar.gz"
+            should contain_staging__file(str).with({
+              'source' => 'http://www.atlassian.com/software/stash/downloads/binary//atlassian-stash-3.6.1.tar.gz',
+              })
+          end
+          it 'should manage the stash home directory' do
+            should contain_file('/home/stash').with({
+              'ensure' => 'directory',
+              'owner' => 'stash',
+              'group' => 'stash'
+              })
+          end
+        end
+      
+        context 'overwriting params' do
+          let(:params) {{
+            :version     => '3.6.1',
+            :product     => 'stash',
+            :format      => 'tar.gz',
+            :installdir  => '/opt/stash',
+            :homedir     => '/random/homedir',
+            :user        => 'foo',
+            :group       => 'bar',
+            :uid         => 333,
+            :gid         => 444,
+            :downloadURL => 'http://downloads.atlassian.com/',
+            :git_version => 'installed',
+          }}
+          it do
+	    should contain_user('foo').with({
+              'home'  => '/random/homedir',
+              'shell' => '/bin/bash',
+              'uid'   => 333,
+              'gid'   => 444
+             })
+	  end
+          it { should contain_group('bar') }
+          it 'should deploy stash 3.6.1 from tar.gz' do
+            should contain_staging__file("atlassian-stash-3.6.1.tar.gz").with({
+              'source' => 'http://downloads.atlassian.com//atlassian-stash-3.6.1.tar.gz',
+              })
+          end 
+          it 'should manage the stash home directory' do
+            should contain_file('/random/homedir').with({
+              'ensure' => 'directory',
+              'owner' => 'foo',
+              'group' => 'bar'
+              })
+          end
+        end
+      
+        context 'specify git version' do
+          let(:params) {{
+            :version => '3.6.1',
+            :git_version => '1.7.12',
+            :staging_or_deploy => 'deploy',
+          }}
+          it 'should ensure a specific version of git is installed' do
+            should contain_package('git').with_ensure('1.7.12')
+          end
+          it { should contain_group('stash') }
+          it { should contain_user('stash').with_shell('/bin/bash') }
+          it 'should deploy stash from tar.gz' do
+            should contain_deploy__file("atlassian-stash-3.6.1.tar.gz")
+          end
+          it 'should manage the stash home directory' do
+            should contain_file('/home/stash').with({
+              'ensure' => 'directory',
+              'owner' => 'stash',
+              'group' => 'stash'
+            })
+          end
+        end
       end
     end
   end
+end
 end

--- a/spec/classes/stash_service_spec.rb
+++ b/spec/classes/stash_service_spec.rb
@@ -1,25 +1,39 @@
 require 'spec_helper.rb'
 
 describe 'stash' do
-  describe 'stash::service' do
-    context 'default params' do
-      it { should contain_service('stash')}
-    end
-    context 'overwriting service_manage param' do
-      let(:params) {{
-        :service_manage => false,
-      }}
-      it { should_not contain_service('stash')}
-    end
-    context 'overwriting service params' do
-      let(:params) {{
-        :service_ensure => 'stopped',
-        :service_enable => false,
-      }}
-      it { should contain_service('stash').with({
-        'ensure' => 'stopped',
-        'enable' => 'false',
-      })}
+describe 'stash::service' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os} #{facts}" do
+        let(:facts) do
+          facts
+        end
+
+        context 'default params' do
+          it { should contain_service('stash')}
+        end
+
+        context 'overwriting service_manage param' do
+          let(:params) {{
+            :service_manage => false,
+          }}
+          it { should_not contain_service('stash')}
+        end
+
+        context 'overwriting service params' do
+          let(:params) {{
+            :service_ensure => 'stopped',
+            :service_enable => false,
+          }}
+          it do
+	    should contain_service('stash').with({
+              'ensure' => 'stopped',
+              'enable' => 'false',
+            })
+          end
+        end
+      end
     end
   end
+end
 end

--- a/spec/classes/stash_upgrade_spec.rb
+++ b/spec/classes/stash_upgrade_spec.rb
@@ -1,17 +1,27 @@
 require 'spec_helper.rb'
 
 describe 'stash' do
-  describe 'stash::install' do
-    context 'default params' do
-      let(:params) {{
-        :javahome    => '/opt/java',
-      }}
-      let(:facts) { {
-        :stash_version  => "3.1.0",
-      }}
-       it 'should stop service and remove old config file' do
-         should contain_exec('service stash stop && sleep 15')
-         should contain_exec('rm -f /home/stash/stash-config.properties')
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os} #{facts}" do
+        let(:facts) do
+          facts
+        end
+        context 'prepare for upgrade of stash' do
+          let(:params) {{
+            :javahome    => '/opt/java',
+          }}
+	  let(:facts) do
+	    facts.merge({ :stash_version  => "3.1.0" })
+	  end
+          it 'should stop service and remove old config file' do
+             should contain_exec('service stash stop && sleep 15')
+             should contain_exec('rm -f /home/stash/stash-config.properties').with({
+               :command => 'rm -f /home/stash/stash-config.properties',
+            })
+            should contain_notify('Attempting to upgrade stash')
+          end
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,20 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
+
+RSpec.configure do |c|
+  c.before do
+    # avoid "Only root can execute commands as other users"
+    Puppet.features.stubs(:root? => true)
+  end
+end
+
 RSpec.configure do |c|
   c.default_facts = {
-    :osfamily           => 'Debian',
-    :augeasversion      => '1.0.0',
-    :staging_http_get   => 'curl',
-    :path               => '/usr/local/bin:/usr/bin:/bin',
-    :stash_version      => '5.5.6',
-    :puppetversion      => '3.7.4',
+    :stash_version    => '3.6.1',
+    :staging_http_get => 'curl',
+    :os_maj_version   => '6',
+    :puppetversion    => '3.7.4',
   }
 end
+


### PR DESCRIPTION
Make use of rspec-puppet-facts fact dumps for testing across
many operating systems.
