### PR TITLE
update stash to the latest version (3.7.0)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@ class stash(
   $java_opts    = '',
 
   # Stash Settings
-  $version      = '3.6.1',
+  $version      = '3.7.0',
   $product      = 'stash',
   $format       = 'tar.gz',
   $installdir   = '/opt/stash',

--- a/spec/classes/stash_config_spec.rb
+++ b/spec/classes/stash_config_spec.rb
@@ -13,20 +13,20 @@ describe 'stash::config' do
           let(:params) do
             {
               :javahome  => '/opt/java',
-              :version   => '3.6.1',
+              :version   => '3.7.0',
            }
           end
-          it do should contain_file('/opt/stash/atlassian-stash-3.6.1/bin/setenv.sh') \
+          it do should contain_file('/opt/stash/atlassian-stash-3.7.0/bin/setenv.sh') \
              .with_content(/JAVA_HOME=\/opt\/java/)
           end
-          it { should contain_file('/opt/stash/atlassian-stash-3.6.1/bin/user.sh')}
-          it { should contain_file('/opt/stash/atlassian-stash-3.6.1/conf/server.xml')}
+          it { should contain_file('/opt/stash/atlassian-stash-3.7.0/bin/user.sh')}
+          it { should contain_file('/opt/stash/atlassian-stash-3.7.0/conf/server.xml')}
           it { should contain_file('/home/stash/shared/stash-config.properties')}
         end
 
         context 'proxy settings ' do
           let(:params) {{
-            :version     => '3.6.1',
+            :version     => '3.7.0',
             :proxy   => {
               'scheme'    => 'https',
               'proxyName' => 'stash.example.co.za',
@@ -34,7 +34,7 @@ describe 'stash::config' do
             },
           }}
           it do
-            should contain_file('/opt/stash/atlassian-stash-3.6.1/conf/server.xml') \
+            should contain_file('/opt/stash/atlassian-stash-3.7.0/conf/server.xml') \
               .with_content(/proxyName = \'stash\.example\.co\.za\'/)
               .with_content(/proxyPort = \'443\'/)
               .with_content(/scheme = \'https\'/)
@@ -44,55 +44,55 @@ describe 'stash::config' do
 
         context 'jvm_xms => 1G' do
           let(:params) {{
-            :version => '3.6.1',
+            :version => '3.7.0',
             :jvm_xms => '1G',
           }}
           it do
-            should contain_file('/opt/stash/atlassian-stash-3.6.1/bin/setenv.sh')
+            should contain_file('/opt/stash/atlassian-stash-3.7.0/bin/setenv.sh')
               .with_content(/^JVM_MINIMUM_MEMORY="1G"/)
           end
         end
 
         context 'jvm_xmx => 4G' do
           let(:params) {{
-            :version => '3.6.1',
+            :version => '3.7.0',
             :jvm_xmx => '4G',
           }}
           it do
-            should contain_file('/opt/stash/atlassian-stash-3.6.1/bin/setenv.sh')
+            should contain_file('/opt/stash/atlassian-stash-3.7.0/bin/setenv.sh')
               .with_content(/^JVM_MAXIMUM_MEMORY="4G"/)
           end
         end
 
         context 'jvm_permgen => 384m' do
           let(:params) {{
-            :version     => '3.6.1',
+            :version     => '3.7.0',
             :jvm_permgen => '384m',
           }}
           it do
-            should contain_file('/opt/stash/atlassian-stash-3.6.1/bin/setenv.sh')
+            should contain_file('/opt/stash/atlassian-stash-3.7.0/bin/setenv.sh')
               .with_content(/^STASH_MAX_PERM_SIZE=384m/)
           end
         end
 
         context 'java_opts => "-Dhttp.proxyHost=proxy.example.co.za -Dhttp.proxyPort=8080"' do
           let(:params) {{
-            :version     => '3.6.1',
+            :version     => '3.7.0',
             :java_opts   => '-Dhttp.proxyHost=proxy.example.co.za -Dhttp.proxyPort=8080',
           }}
           it do
-            should contain_file('/opt/stash/atlassian-stash-3.6.1/bin/setenv.sh')
+            should contain_file('/opt/stash/atlassian-stash-3.7.0/bin/setenv.sh')
               .with_content(/JAVA_OPTS="-Dhttp\.proxyHost=proxy\.example\.co\.za -Dhttp\.proxyPort=8080/)
           end
         end
 
         context 'context_path => "stash"' do
           let(:params) {{
-            :version      => '3.6.1',
+            :version      => '3.7.0',
             :context_path => '/stash',
           }}
           it do
-            should contain_file('/opt/stash/atlassian-stash-3.6.1/conf/server.xml')
+            should contain_file('/opt/stash/atlassian-stash-3.7.0/conf/server.xml')
               .with_content(/path="\/stash"/)
           end
         end

--- a/spec/classes/stash_install_deploy_spec.rb
+++ b/spec/classes/stash_install_deploy_spec.rb
@@ -11,7 +11,7 @@ describe 'stash::install' do
 
         context 'install stash with deploy module' do
           let(:params) {{
-            :version => '3.6.1',
+            :version => '3.7.0',
             :staging_or_deploy => 'deploy',
           }}
           it 'should install, but not upgrade, git' do
@@ -19,8 +19,8 @@ describe 'stash::install' do
           end
           it { should contain_group('stash') }
           it { should contain_user('stash').with_shell('/bin/bash') }
-          it 'should deploy stash 3.6.1 from tar.gz' do
-            should contain_deploy__file("atlassian-stash-3.6.1.tar.gz")
+          it 'should deploy stash 3.7.0 from tar.gz' do
+            should contain_deploy__file("atlassian-stash-3.7.0.tar.gz")
           end
           it 'should manage the stash home directory' do
             should contain_file('/home/stash').with({
@@ -33,7 +33,7 @@ describe 'stash::install' do
 
         context 'overwriting params' do
           let(:params) {{
-            :version => '3.6.1',
+            :version => '3.7.0',
             :product => 'stash',
             :format => 'tar.gz',
             :installdir => '/opt/stash',
@@ -54,8 +54,8 @@ describe 'stash::install' do
             })
           end
           it { should contain_group('bar') }
-          it 'should deploy stash 3.6.1 from tar.gz' do
-            should contain_deploy__file("atlassian-stash-3.6.1.tar.gz").with({
+          it 'should deploy stash 3.7.0 from tar.gz' do
+            should contain_deploy__file("atlassian-stash-3.7.0.tar.gz").with({
               'url' => 'http://downloads.atlassian.com/',
               'owner' => 'foo',
               'group' => 'bar'
@@ -72,7 +72,7 @@ describe 'stash::install' do
 
         context 'specify git version' do
           let(:params) {{
-            :version => '3.6.1',
+            :version => '3.7.0',
             :git_version => '1.7.12',
             :staging_or_deploy => 'deploy',
             }}
@@ -82,8 +82,8 @@ describe 'stash::install' do
           end
           it { should contain_group('stash') }
           it { should contain_user('stash').with_shell('/bin/bash') }
-          it 'should deploy stash 3.6.1 from tar.gz' do
-            should contain_deploy__file("atlassian-stash-3.6.1.tar.gz")
+          it 'should deploy stash 3.7.0 from tar.gz' do
+            should contain_deploy__file("atlassian-stash-3.7.0.tar.gz")
           end
           it 'should manage the stash home directory' do
             should contain_file('/home/stash').with({

--- a/spec/classes/stash_install_staging_spec.rb
+++ b/spec/classes/stash_install_staging_spec.rb
@@ -10,7 +10,7 @@ describe 'stash::install' do
         end
         context 'install stash with deploy module' do
           let(:params) {{
-            :version => '3.6.1',
+            :version => '3.7.0',
           }}
           it 'should install, but not upgrade, git' do
             should contain_package('git').with_ensure('installed')
@@ -18,9 +18,9 @@ describe 'stash::install' do
           it { should contain_group('stash') }
           it { should contain_user('stash').with_shell('/bin/bash') }
           it 'should deploy stash from tar.gz' do
-	    str = "atlassian-stash-3.6.1.tar.gz"
+	    str = "atlassian-stash-3.7.0.tar.gz"
             should contain_staging__file(str).with({
-              'source' => 'http://www.atlassian.com/software/stash/downloads/binary//atlassian-stash-3.6.1.tar.gz',
+              'source' => 'http://www.atlassian.com/software/stash/downloads/binary//atlassian-stash-3.7.0.tar.gz',
               })
           end
           it 'should manage the stash home directory' do
@@ -34,7 +34,7 @@ describe 'stash::install' do
       
         context 'overwriting params' do
           let(:params) {{
-            :version     => '3.6.1',
+            :version     => '3.7.0',
             :product     => 'stash',
             :format      => 'tar.gz',
             :installdir  => '/opt/stash',
@@ -55,9 +55,9 @@ describe 'stash::install' do
              })
 	  end
           it { should contain_group('bar') }
-          it 'should deploy stash 3.6.1 from tar.gz' do
-            should contain_staging__file("atlassian-stash-3.6.1.tar.gz").with({
-              'source' => 'http://downloads.atlassian.com//atlassian-stash-3.6.1.tar.gz',
+          it 'should deploy stash 3.7.0 from tar.gz' do
+            should contain_staging__file("atlassian-stash-3.7.0.tar.gz").with({
+              'source' => 'http://downloads.atlassian.com//atlassian-stash-3.7.0.tar.gz',
               })
           end 
           it 'should manage the stash home directory' do
@@ -71,7 +71,7 @@ describe 'stash::install' do
       
         context 'specify git version' do
           let(:params) {{
-            :version => '3.6.1',
+            :version => '3.7.0',
             :git_version => '1.7.12',
             :staging_or_deploy => 'deploy',
           }}
@@ -81,7 +81,7 @@ describe 'stash::install' do
           it { should contain_group('stash') }
           it { should contain_user('stash').with_shell('/bin/bash') }
           it 'should deploy stash from tar.gz' do
-            should contain_deploy__file("atlassian-stash-3.6.1.tar.gz")
+            should contain_deploy__file("atlassian-stash-3.7.0.tar.gz")
           end
           it 'should manage the stash home directory' do
             should contain_file('/home/stash').with({

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ end
 
 RSpec.configure do |c|
   c.default_facts = {
-    :stash_version    => '3.6.1',
+    :stash_version    => '3.7.0',
     :staging_http_get => 'curl',
     :os_maj_version   => '6',
     :puppetversion    => '3.7.4',


### PR DESCRIPTION
Stash 3.7.0 is released, our module supports its installation as well as
the upgrade path flawlessly. Switch it on as default.

This pull request addresses #46
