### PR TITLE
Issue #61, stash backup should be able to cleanup old archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ###Summary
 
 - Issue #58, Do not hard code java path in backup class.
+- Issue #61, stash backup should be able to cleanup old archives.
 
 ##2015-02-24 - Release 1.2.2
 ###Summary

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Enable a stash backup
     backup_home         => '/opt/stash-backup',
     backupuser          => 'admin',
     backuppass          => 'password',
+    backup_keep_age     => '3d',
   }
 ```
 
@@ -284,6 +285,8 @@ Home directory to use for backups. Backups are created here under /archive. Defa
 The username to use to initiate the stash backup. Defaults to 'admin'
 #####`backuppass`
 The password to use to initiate the stash backup. Defaults to 'password'
+#####`backup_keep_age`
+How long to keep the backup archives for. You can choose seconds, minutes, hours, days, or weeks by specifying the first letter of any of those words (e.g., ‘1w’). Specifying 0 will remove all files.
 
 ##Limitations
 * Puppet 3.4+

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -17,6 +17,7 @@ class stash::backup(
   $s_or_d               = $stash::staging_or_deploy,
   $backup_home          = $stash::backup_home,
   $javahome             = $stash::javahome,
+  $keep_age             = $stash::backup_keep_age,
   ) {
 
   $appdir = "${backup_home}/${product}-backup-client-${version}"
@@ -92,4 +93,13 @@ class stash::backup(
     hour    => 5,
     minute  => 0,
   }
+
+  tidy { 'remove_old_archives': 
+    path    => "${backup_home}/archives",
+    age     => $keep_age,
+    matches => "*.tar",
+    type    => 'mtime',
+    recurse => 1,
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,7 @@ class stash(
   $backup_home         = '/opt/stash-backup',
   $backupuser          = 'admin',
   $backuppass          = 'password',
+  $backup_keep_age     = '4w',
 
   # Manage service
   $service_manage = true,

--- a/spec/classes/stash_backup_spec.rb
+++ b/spec/classes/stash_backup_spec.rb
@@ -47,6 +47,15 @@ describe 'stash::backup' do
               'minute'  => '0',
             })
           end
+          it 'should remove old archives' do
+            should contain_tidy('remove_old_archives').with({
+              'path'    => '/opt/stash-backup/archives',
+              'age'     => '4w',
+              'matches' => '*.tar',
+              'type'    => 'mtime',
+              'recurse' => 1,
+            })
+          end
         end
 
         context 'install stash backup client with deploy module' do
@@ -119,6 +128,19 @@ describe 'stash::backup' do
             should contain_class('stash').with_backupuser('myuser').with_backuppass('mypass')
             should contain_cron('Backup Stash').with({
               'command' => '/usr/bin/java -Dstash.password="mypass" -Dstash.user="myuser" -Dstash.baseUrl="http://localhost:7990" -Dstash.home=/home/stash -Dbackup.home=/opt/stash-backup/archives -jar /opt/stash-backup/stash-backup-client-1.6.0/stash-backup-client.jar',
+            })
+          end
+        end
+
+        context 'should remove old archives' do
+          let(:params) {{
+            :backup_keep_age => '1y',
+            :backup_home     => '/my/backup',
+          }}
+          it do
+            should contain_tidy('remove_old_archives').with({
+              'path'=> '/my/backup/archives',
+              'age' => '1y',
             })
           end
         end


### PR DESCRIPTION
Add parameter 'backup_keep_age'.  This parameters specifies how
long to keep the backup archives for. You can choose seconds,
minutes, hours, days, or weeks by specifying the first letter
of any of those words (e.g., ‘1w’). Specifying 0 will remove
all files.
