### PR TITLE
Fix tomcat port in service output

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,6 @@ fixtures:
   repositories:
     deploy: "http://github.com/mkrakowitzer/puppet-deploy"
     stdlib: "http://github.com/puppetlabs/puppetlabs-stdlib.git"
+    inifile: "http://github.com/puppetlabs/puppetlabs-inifile.git"
     repoforge: "http://github.com/Mylezeem/puppet-repoforge.git"
     staging: "http://github.com/nanliu/puppet-staging"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,6 +54,16 @@ class stash::config(
     notify  => Class['stash::service'],
   } ->
 
+  ini_setting { 'stash_httpport':
+    ensure  => present,
+    path    => "${stash::webappdir}/conf/scripts.cfg",
+    section => '',
+    setting => 'stash_httpport',
+    value   => $tomcat_port,
+    require => Class['stash::install'],
+    before  => Class['stash::service'],
+  } ->
+
   file { "${stash::homedir}/${moved}stash-config.properties":
     content => template('stash/stash-config.properties.erb'),
     mode    => '0750',

--- a/metadata.json
+++ b/metadata.json
@@ -43,6 +43,10 @@
       "version_requirement": ">= 4.0.0"
     },
     {
+      "name": "puppetlabs/inifile",
+      "version_requirement": ">= 1.0.0"
+    },
+    {
       "name": "mkrakowitzer/deploy",
       "version_requirement": ">= 0.0.3"
     },

--- a/spec/classes/stash_config_spec.rb
+++ b/spec/classes/stash_config_spec.rb
@@ -14,6 +14,7 @@ describe 'stash::config' do
             {
               :javahome  => '/opt/java',
               :version   => '3.7.0',
+              :tomcat_port => '7990',
            }
           end
           it do
@@ -30,9 +31,9 @@ describe 'stash::config' do
             should contain_file('/opt/stash/atlassian-stash-3.7.0/conf/server.xml')
               .with_content(/<Connector port="7990"/)
               .with_content(/path=""/)
-              .without_content(/proxyName/) 
-              .without_content(/proxyPort/) 
-              .without_content(/scheme/) 
+              .without_content(/proxyName/)
+              .without_content(/proxyPort/)
+              .without_content(/scheme/)
           end
 
           it do
@@ -41,6 +42,12 @@ describe 'stash::config' do
               .with_content(/jdbc\.url=jdbc:postgresql:\/\/localhost:5432\/stash/)
               .with_content(/jdbc\.user=stash/)
               .with_content(/jdbc\.password=password/)
+          end
+
+          it do
+            should contain_ini_setting('stash_httpport').with({
+              'value' => '7990',
+            })
           end
         end
 
@@ -124,6 +131,12 @@ describe 'stash::config' do
           it do
             should contain_file('/opt/stash/atlassian-stash-3.7.0/conf/server.xml')
               .with_content(/<Connector port="7991"/)
+          end
+
+          it do
+            should contain_ini_setting('stash_httpport').with({
+              'value' => '7991',
+            })
           end
         end
       end


### PR DESCRIPTION
This fixes the service start/stop to display the correct ports:

Success! You can now use Stash at the following address:

http://localhost:8080/
