### PR TITLE
Add more granular control around the stash user and group.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ The format of the file stash will be installed from. Default: 'tar.gz'
 The installation directory of the stash binaries. Default: '/opt/stash'
 #####`homedir`
 The home directory of stash. Configuration files are stored here. Default: '/home/stash'
+#####`manage_usr_grp`
+Whether or not this module will manage the stash user and group associated with the install. 
+You must either allow the module to manage both aspects or handle both outside the module. Default: true
 #####`user`
 The user that stash should run as, as well as the ownership of stash related files. Default: 'stash'
 #####`group`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,12 +23,11 @@ class stash(
   $tomcat_port  = 7990,
 
   # User and Group Management Settings
-  $user         = 'stash',
-  $user_manage  = true,
-  $group        = 'stash',
-  $group_manage = true,
-  $uid          = undef,
-  $gid          = undef,
+  $manage_usr_grp = true,
+  $user           = 'stash',
+  $group          = 'stash',
+  $uid            = undef,
+  $gid            = undef,
 
   # Stash 3.8 initialization configurations
   $display_name  = 'stash',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,12 +19,16 @@ class stash(
   $format       = 'tar.gz',
   $installdir   = '/opt/stash',
   $homedir      = '/home/stash',
-  $user         = 'stash',
-  $group        = 'stash',
-  $uid          = undef,
-  $gid          = undef,
   $context_path = '',
   $tomcat_port  = 7990,
+
+  # User and Group Management Settings
+  $user         = 'stash',
+  $user_manage  = true,
+  $group        = 'stash',
+  $group_manage = true,
+  $uid          = undef,
+  $gid          = undef,
 
   # Stash 3.8 initialization configurations
   $display_name  = 'stash',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,20 +3,22 @@
 # This installs the stash module. See README.md for details
 #
 class stash::install(
-  $version     = $stash::version,
-  $product     = $stash::product,
-  $format      = $stash::format,
-  $installdir  = $stash::installdir,
-  $homedir     = $stash::homedir,
-  $user        = $stash::user,
-  $group       = $stash::group,
-  $uid         = $stash::uid,
-  $gid         = $stash::gid,
-  $git_version = $stash::git_version,
-  $repoforge   = $stash::repoforge,
-  $downloadURL = $stash::downloadURL,
-  $s_or_d      = $stash::staging_or_deploy,
-  $git_manage  = $stash::git_manage,
+  $version      = $stash::version,
+  $product      = $stash::product,
+  $format       = $stash::format,
+  $installdir   = $stash::installdir,
+  $homedir      = $stash::homedir,
+  $user         = $stash::user,
+  $user_manage  = $stash::user_manage,
+  $group        = $stash::group,
+  $group_manage = $stash::group_manage,
+  $uid          = $stash::uid,
+  $gid          = $stash::gid,
+  $git_version  = $stash::git_version,
+  $repoforge    = $stash::repoforge,
+  $downloadURL  = $stash::downloadURL,
+  $s_or_d       = $stash::staging_or_deploy,
+  $git_manage   = $stash::git_manage,
 
   $webappdir
   ) {
@@ -52,21 +54,25 @@ class stash::install(
     }
   }
 
-  group { $group:
-    ensure => present,
-    gid    => $gid
-  } ->
+  if $group_manage {
+    group { $group:
+      ensure => present,
+      gid    => $gid,
+    }
+  }
 
-  user { $user:
-    comment          => 'Stash daemon account',
-    shell            => '/bin/bash',
-    home             => $homedir,
-    password         => '*',
-    password_min_age => '0',
-    password_max_age => '99999',
-    managehome       => true,
-    uid              => $uid,
-    gid              => $gid,
+  if $user_manage {
+    user { $user:
+      comment          => 'Stash daemon account',
+      shell            => '/bin/bash',
+      home             => $homedir,
+      password         => '*',
+      password_min_age => '0',
+      password_max_age => '99999',
+      managehome       => true,
+      uid              => $uid,
+      gid              => $gid,
+    }
   }
 
   if ! defined(File[$installdir]) {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,22 +3,21 @@
 # This installs the stash module. See README.md for details
 #
 class stash::install(
-  $version      = $stash::version,
-  $product      = $stash::product,
-  $format       = $stash::format,
-  $installdir   = $stash::installdir,
-  $homedir      = $stash::homedir,
-  $user         = $stash::user,
-  $user_manage  = $stash::user_manage,
-  $group        = $stash::group,
-  $group_manage = $stash::group_manage,
-  $uid          = $stash::uid,
-  $gid          = $stash::gid,
-  $git_version  = $stash::git_version,
-  $repoforge    = $stash::repoforge,
-  $downloadURL  = $stash::downloadURL,
-  $s_or_d       = $stash::staging_or_deploy,
-  $git_manage   = $stash::git_manage,
+  $version        = $stash::version,
+  $product        = $stash::product,
+  $format         = $stash::format,
+  $installdir     = $stash::installdir,
+  $homedir        = $stash::homedir,
+  $manage_usr_grp = $stash::manage_usr_grp,
+  $user           = $stash::user,
+  $group          = $stash::group,
+  $uid            = $stash::uid,
+  $gid            = $stash::gid,
+  $git_version    = $stash::git_version,
+  $repoforge      = $stash::repoforge,
+  $downloadURL    = $stash::downloadURL,
+  $s_or_d         = $stash::staging_or_deploy,
+  $git_manage     = $stash::git_manage,
 
   $webappdir
   ) {
@@ -54,14 +53,13 @@ class stash::install(
     }
   }
 
-  if $group_manage {
+  if $manage_usr_grp {
+    #Manage the group in the module
     group { $group:
       ensure => present,
       gid    => $gid,
     }
-  }
-
-  if $user_manage {
+    #Manage the user in the module
     user { $user:
       comment          => 'Stash daemon account',
       shell            => '/bin/bash',

--- a/spec/classes/stash_install_deploy_spec.rb
+++ b/spec/classes/stash_install_deploy_spec.rb
@@ -50,20 +50,21 @@ describe 'stash::install' do
         end
 
         context 'when managing the user and group outside the module' do
-          let(:params) {{
-            :manage_usr_grp  => false,
-          }}
           context 'when no user or group are specified' do
+            let(:params) {{
+              :manage_usr_grp  => false
+            }}
             it {  should_not contain_user('stash') }
             it {  should_not contain_group('stash') }
           end
           context 'when a user and group is specified' do
             let(:params) {{
-              :user  => 'mystashuser',
-              :group => 'mystashgroup'
+              :user           => 'mystashuser',
+              :group          => 'mystashgroup',
+              :manage_usr_grp => false
             }}
-            it {  should_not contain_user('stash') }
-            it {  should_not contain_group('stash') }
+            it {  should_not contain_user('mystashuser') }
+            it {  should_not contain_group('mystashgroup') }
           end
         end
 

--- a/spec/classes/stash_install_deploy_spec.rb
+++ b/spec/classes/stash_install_deploy_spec.rb
@@ -33,8 +33,7 @@ describe 'stash::install' do
 
         context 'when managing the user and group inside the module' do
           let(:params) {{
-            :user_manage  => 'true',
-            :group_manage => 'true'
+            :manage_usr_grp  => true,
           }}
           context 'when no user or group are specified' do
             it { should contain_user('stash') }
@@ -52,54 +51,19 @@ describe 'stash::install' do
 
         context 'when managing the user and group outside the module' do
           let(:params) {{
-            :user_manage  => 'false',
-            :group_manage => 'false',
+            :manage_usr_grp  => false,
           }}
           context 'when no user or group are specified' do
-            it do
-              should_not contain_user('stash').with({
-                'comment'          => 'Stash daemon account',
-                'shell'            => '/bin/bash',
-                'home'             => '/test/my/dir',
-                'password'         => '*',
-                'password_min_age' => '0',
-                'password_max_age' => '99999',
-                'managehome'       => true,
-                'uid'              => '1234',
-                'gid'              => '5678' 
-              })
-            end 
-            it do
-              should_not contain_group('stash').with({
-                'ensure' => 'present',
-                'gid'    => '5678' 
-              })                                      
-            end
+            it {  should_not contain_user('stash') }
+            it {  should_not contain_group('stash') }
           end
           context 'when a user and group is specified' do
             let(:params) {{
               :user  => 'mystashuser',
               :group => 'mystashgroup'
             }}
-            it do
-              should_not contain_user('mystashuser').with({
-                'comment'          => 'Stash daemon account',
-                'shell'            => '/bin/bash',
-                'home'             => '/test/my/dir',
-                'password'         => '*',
-                'password_min_age' => '0',
-                'password_max_age' => '99999',
-                'managehome'       => true,
-                'uid'              => '1234',
-                'gid'              => '5678' 
-              })
-            end 
-            it do
-              should_not contain_group('mystashgroup').with({
-                'ensure' => 'present',
-                'gid'    => '5678' 
-              })
-            end
+            it {  should_not contain_user('stash') }
+            it {  should_not contain_group('stash') }
           end
         end
 

--- a/spec/classes/stash_install_deploy_spec.rb
+++ b/spec/classes/stash_install_deploy_spec.rb
@@ -31,6 +31,78 @@ describe 'stash::install' do
           end
         end
 
+        context 'when managing the user and group inside the module' do
+          let(:params) {{
+            :user_manage  => 'true',
+            :group_manage => 'true'
+          }}
+          context 'when no user or group are specified' do
+            it { should contain_user('stash') }
+            it { should contain_group('stash') }
+          end
+          context 'when a user and group is specified' do
+            let(:params) {{
+              :user  => 'mystashuser',
+              :group => 'mystashgroup'
+            }}
+            it { should contain_user('mystashuser') }
+            it { should contain_group('mystashgroup') }
+          end
+        end
+
+        context 'when managing the user and group outside the module' do
+          let(:params) {{
+            :user_manage  => 'false',
+            :group_manage => 'false',
+          }}
+          context 'when no user or group are specified' do
+            it do
+              should_not contain_user('stash').with({
+                'comment'          => 'Stash daemon account',
+                'shell'            => '/bin/bash',
+                'home'             => '/test/my/dir',
+                'password'         => '*',
+                'password_min_age' => '0',
+                'password_max_age' => '99999',
+                'managehome'       => true,
+                'uid'              => '1234',
+                'gid'              => '5678' 
+              })
+            end 
+            it do
+              should_not contain_group('stash').with({
+                'ensure' => 'present',
+                'gid'    => '5678' 
+              })                                      
+            end
+          end
+          context 'when a user and group is specified' do
+            let(:params) {{
+              :user  => 'mystashuser',
+              :group => 'mystashgroup'
+            }}
+            it do
+              should_not contain_user('mystashuser').with({
+                'comment'          => 'Stash daemon account',
+                'shell'            => '/bin/bash',
+                'home'             => '/test/my/dir',
+                'password'         => '*',
+                'password_min_age' => '0',
+                'password_max_age' => '99999',
+                'managehome'       => true,
+                'uid'              => '1234',
+                'gid'              => '5678' 
+              })
+            end 
+            it do
+              should_not contain_group('mystashgroup').with({
+                'ensure' => 'present',
+                'gid'    => '5678' 
+              })
+            end
+          end
+        end
+
         context 'overwriting params' do
           let(:params) {{
             :version => '3.7.0',

--- a/spec/classes/stash_install_staging_spec.rb
+++ b/spec/classes/stash_install_staging_spec.rb
@@ -32,6 +32,78 @@ describe 'stash::install' do
           end
         end
       
+        context 'when managing the user and group outside the module' do
+          let(:params) {{
+            :user_manage  => 'false',
+            :group_manage => 'false',
+          }}
+          context 'when no user or group are specified' do
+            it do
+              should_not contain_user('stash').with({
+                'comment'          => 'Stash daemon account',
+                'shell'            => '/bin/bash',
+                'home'             => '/test/my/dir',
+                'password'         => '*',
+                'password_min_age' => '0',
+                'password_max_age' => '99999',
+                'managehome'       => true,
+                'uid'              => '1234',
+                'gid'              => '5678' 
+              })
+            end 
+            it do
+              should_not contain_group('stash').with({
+                'ensure' => 'present',
+                'gid'    => '5678' 
+              })
+            end
+          end
+          context 'when a user and group is specified' do
+            let(:params) {{
+              :user  => 'mystashuser',
+              :group => 'mystashgroup'
+            }}
+            it do
+              should_not contain_user('mystashuser').with({
+                'comment'          => 'Stash daemon account',
+                'shell'            => '/bin/bash',
+                'home'             => '/test/my/dir',
+                'password'         => '*',
+                'password_min_age' => '0',
+                'password_max_age' => '99999',
+                'managehome'       => true,
+                'uid'              => '1234',
+                'gid'              => '5678' 
+              })
+            end 
+            it do
+              should_not contain_group('mystashgroup').with({
+                'ensure' => 'present',
+                'gid'    => '5678'
+              })
+            end
+          end
+        end
+
+        #context 'when managing the user and group inside the module' do
+        #  let(:params) {{
+        #    :user_manage  => 'true',
+        #    :group_manage => 'true'
+        #  }}
+        #  context 'when no user or group are specified' do
+        #    it { should contain_user('stash') }
+        #    it { should contain_group('stash') }
+        #  end
+        #  context 'when a user and group is specified' do
+        #    let(:params) {{
+        #      :user  => 'mystashuser',
+        #      :group => 'mystashgroup'
+        #    }}
+        #    it { should contain_user('mystashuser') }
+        #    it { should contain_group('mystashgroup') }
+        #  end
+        #end
+
         context 'overwriting params' do
           let(:params) {{
             :version     => '3.7.0',

--- a/spec/classes/stash_install_staging_spec.rb
+++ b/spec/classes/stash_install_staging_spec.rb
@@ -32,77 +32,41 @@ describe 'stash::install' do
           end
         end
       
-        context 'when managing the user and group outside the module' do
+        context 'when managing the user and group inside the module' do
           let(:params) {{
-            :user_manage  => 'false',
-            :group_manage => 'false',
+            :manage_usr_grp  => true,
           }}
           context 'when no user or group are specified' do
-            it do
-              should_not contain_user('stash').with({
-                'comment'          => 'Stash daemon account',
-                'shell'            => '/bin/bash',
-                'home'             => '/test/my/dir',
-                'password'         => '*',
-                'password_min_age' => '0',
-                'password_max_age' => '99999',
-                'managehome'       => true,
-                'uid'              => '1234',
-                'gid'              => '5678' 
-              })
-            end 
-            it do
-              should_not contain_group('stash').with({
-                'ensure' => 'present',
-                'gid'    => '5678' 
-              })
-            end
+            it { should contain_user('stash') }
+            it { should contain_group('stash') }
           end
           context 'when a user and group is specified' do
             let(:params) {{
               :user  => 'mystashuser',
               :group => 'mystashgroup'
             }}
-            it do
-              should_not contain_user('mystashuser').with({
-                'comment'          => 'Stash daemon account',
-                'shell'            => '/bin/bash',
-                'home'             => '/test/my/dir',
-                'password'         => '*',
-                'password_min_age' => '0',
-                'password_max_age' => '99999',
-                'managehome'       => true,
-                'uid'              => '1234',
-                'gid'              => '5678' 
-              })
-            end 
-            it do
-              should_not contain_group('mystashgroup').with({
-                'ensure' => 'present',
-                'gid'    => '5678'
-              })
-            end
+            it { should contain_user('mystashuser') }
+            it { should contain_group('mystashgroup') }
           end
         end
 
-        #context 'when managing the user and group inside the module' do
-        #  let(:params) {{
-        #    :user_manage  => 'true',
-        #    :group_manage => 'true'
-        #  }}
-        #  context 'when no user or group are specified' do
-        #    it { should contain_user('stash') }
-        #    it { should contain_group('stash') }
-        #  end
-        #  context 'when a user and group is specified' do
-        #    let(:params) {{
-        #      :user  => 'mystashuser',
-        #      :group => 'mystashgroup'
-        #    }}
-        #    it { should contain_user('mystashuser') }
-        #    it { should contain_group('mystashgroup') }
-        #  end
-        #end
+        context 'when managing the user and group outside the module' do
+          let(:params) {{
+            :manage_usr_grp  => false,
+          }}
+          context 'when no user or group are specified' do
+            it {  should_not contain_user('stash') }
+            it {  should_not contain_group('stash') }
+          end
+          context 'when a user and group is specified' do
+            let(:params) {{
+              :user  => 'mystashuser',
+              :group => 'mystashgroup'
+            }}
+            it {  should_not contain_user('stash') }
+            it {  should_not contain_group('stash') }
+          end
+        end
 
         context 'overwriting params' do
           let(:params) {{

--- a/spec/classes/stash_install_staging_spec.rb
+++ b/spec/classes/stash_install_staging_spec.rb
@@ -51,20 +51,21 @@ describe 'stash::install' do
         end
 
         context 'when managing the user and group outside the module' do
-          let(:params) {{
-            :manage_usr_grp  => false,
-          }}
           context 'when no user or group are specified' do
+            let(:params) {{
+              :manage_usr_grp  => false
+            }}
             it {  should_not contain_user('stash') }
             it {  should_not contain_group('stash') }
           end
           context 'when a user and group is specified' do
             let(:params) {{
-              :user  => 'mystashuser',
-              :group => 'mystashgroup'
+              :user           => 'mystashuser',
+              :group          => 'mystashgroup',
+              :manage_usr_grp => false
             }}
-            it {  should_not contain_user('stash') }
-            it {  should_not contain_group('stash') }
+            it {  should_not contain_user('mystashuser') }
+            it {  should_not contain_group('mystashgroup') }
           end
         end
 


### PR DESCRIPTION
- Give individuals the capability to manage the stash user and group
  outside the context of the stash module as other supporting
  directories or items might also be using these same resources.
- Given the above, individuals would still want the ability to manage
  these resources with puppet.  These changes support that functionality.
- Default values for the user_manage and group_manage parameters are set to
  true, so that the module maintains prior behavior/backwards compatibility.
