### PR TITLE
Removed reference to permgen.sh

### DIFF
--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -82,19 +82,9 @@ fi
 
 JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JAVA_OPTS} ${JVM_REQUIRED_ARGS} ${JVM_SUPPORT_RECOMMENDED_ARGS} ${STASH_HOME_MINUSD}"
 
-# PermGen size needs to be increased if encountering OutOfMemoryError: PermGen problems. Specifying PermGen size is
-# not valid on IBM JDKs
+# PermGen size needs to be increased if encountering OutOfMemoryError: PermGen problems.
 STASH_MAX_PERM_SIZE=<%= scope.lookupvar('stash::jvm_permgen') %>
-if [ -f "${PRGDIR}/permgen.sh" ]; then
-    echo "Detecting JVM PermGen support..."
-    . "${PRGDIR}/permgen.sh"
-    if [ $JAVA_PERMGEN_SUPPORTED = "true" ]; then
-        echo "PermGen switch is supported. Setting to ${STASH_MAX_PERM_SIZE}\n"
-        JAVA_OPTS="-XX:MaxPermSize=${STASH_MAX_PERM_SIZE} ${JAVA_OPTS}"
-    else
-        echo "PermGen switch is NOT supported and will NOT be set automatically.\n"
-    fi
-fi
+JAVA_OPTS="-XX:MaxPermSize=${MAX_PERM_SIZE} ${JAVA_OPTS}"
 
 export JAVA_OPTS
 

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -84,7 +84,7 @@ JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JAVA_OPTS} ${JV
 
 # PermGen size needs to be increased if encountering OutOfMemoryError: PermGen problems.
 STASH_MAX_PERM_SIZE=<%= scope.lookupvar('stash::jvm_permgen') %>
-JAVA_OPTS="-XX:MaxPermSize=${MAX_PERM_SIZE} ${JAVA_OPTS}"
+JAVA_OPTS="-XX:MaxPermSize=${STASH_MAX_PERM_SIZE} ${JAVA_OPTS}"
 
 export JAVA_OPTS
 


### PR DESCRIPTION
Per https://confluence.atlassian.com/display/STASHKB/Stash+crashes+due+to+java.lang.OutOfMemoryError+PermGen+Space+Error,
"if setenv.sh was copied over from Stash 3.7- to an environment running on Java 7, the test to check if using PermGen is allowed always returns false since permgen.sh is no longer shipped with Stash 3.8+ and the PermGen size gets set to the default in Java 7, which is too small for Stash and causes the Out of Memory Error."
