### PR TITLE
Issue #85 - add global parameter for stash-config.properties values

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ Enable the repoforge yum repository by default for RHEL as stash requires a newe
 By default we will upgrade git to a supported version if it is already installed and the repoforge repository was not enabled. Default: true
 #####`$staging_or_deploy`
 Choose whether to use nanliu-staging, or mkrakowitzer-deploy. Defaults to 'staging' to use nanliu-staging as it is puppetlabs approved. Alternative option is 'deploy' to use mkrakowitzer-deploy.
+#####`config_properties`
+Extra configuration options for stash (stash-config.properties). See https://confluence.atlassian.com/display/STASH/Stash+config+properties for available options. Must be a hash, Default: {}
 
 ####Backup parameters####
 #####`backup_ensure`

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,6 +9,7 @@ class stash::config(
   $proxy        = $stash::proxy,
   $context_path = $stash::context_path,
   $tomcat_port  = $stash::tomcat_port,
+  $config_properties = $stash::config_properties,
 ) {
 
   # Atlassian changed where files are installed from ver 3.2.0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@ class stash(
   $sysadmin_password = 'stash',
   $sysadmin_name  = 'Stash Admin',
   $sysadmin_email = '',
+  $config_properties = {},
 
   # Database Settings
   $dbuser       = 'stash',
@@ -83,6 +84,7 @@ class stash(
 ) {
 
   validate_bool($git_manage)
+  validate_hash($config_properties)
 
   include stash::params
 

--- a/spec/classes/stash_config_spec.rb
+++ b/spec/classes/stash_config_spec.rb
@@ -69,6 +69,43 @@ describe 'stash::config' do
           end
         end
 
+        context 'stash 3.8.1 with additional stash-config.properties values' do
+          let(:params) do
+            {
+              :version   => '3.8.1',
+              :config_properties => {
+                'aaaa'   => 'bbbb',
+                'cccc'   => 'dddd',
+              },
+            }
+          end
+
+          it do
+            should contain_file('/home/stash/shared/stash-config.properties')
+              .with_content(/^aaaa=bbbb$/)
+              .with_content(/^cccc=dddd$/)
+          end
+        end
+
+        context 'stash 3.7.0 with additional stash-config.properties values' do
+          let(:params) do
+            {
+              :version   => '3.7.0',
+              :config_properties => {
+                'aaaa'   => 'bbbb',
+                'cccc'   => 'dddd',
+              },
+            }
+          end
+
+          it do
+            should_not contain_file('/home/stash/shared/stash-config.properties')
+              .with_content(/^aaaa=bbbb$/)
+              .with_content(/^cccc=dddd$/)
+          end
+        end
+
+
         context 'proxy settings ' do
           let(:params) {{
             :version     => '3.7.0',

--- a/templates/stash-config.properties.erb
+++ b/templates/stash-config.properties.erb
@@ -6,6 +6,9 @@ setup.sysadmin.username=<%= scope['stash::sysadmin_username'] %>
 setup.sysadmin.password=<%= scope['stash::sysadmin_password'] %>
 setup.sysadmin.displayName=<%= scope['stash::sysadmin_name'] %>
 setup.sysadmin.emailAddress=<%= scope['stash::sysadmin_email'] %>
+<%- @config_properties.sort.each do |key,value| -%>
+<%=   key %>=<%= value %>
+<%- end -%>
 <% end -%>
 jdbc.driver=<%= scope.lookupvar('stash::dbdriver') %>
 jdbc.url=<%= scope.lookupvar('stash::dburl') %>


### PR DESCRIPTION
Add parameter config_properties. Accepts a hash. Defaults to {}
eg:

```
config_properties => {
  'aaaa'   => 'bbbb',
  'cccc'   => 'dddd',
},
```
