### PR TITLE
Remove wrong archive module call 

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,8 +26,6 @@ class stash::install(
   $webappdir,
   ) {
 
-  include '::archive'
-  
   if $git_manage {
     if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' {
       validate_bool($repoforge)


### PR DESCRIPTION
As now deploy_module (puppet-staging and puppet-archive) is handled later in this manifest, furtermore archive is a puppet ressource, not a class
