### PR TITLE
Remove support for upstream mysql java connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ##2015-XX-XX - Release 2.0.0
 ###Summary
+- Remove support for installing upstream java mysql connector
 - Remove support for installing git, a git module should be used
 
 ##2015-07-16 - Release 1.3.0

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This module installs/upgrades Atlassian's Enterprise source code management tool
 ###What Stash affects
 If installing to an existing Stash instance, it is your responsibility to backup your database. We also recommend that you backup your Stash home directory and that you align your current Stash version with the version you intend to use with puppet Stash module.
 
-You must have your database setup with the account user that Stash will use. This can be done using the puppetlabs-postgresql and puppetlabs-mysql modules.
+You must have your database setup with the account user that Stash will use. This can be done using the puppetlabs-postgresql and puppetlabs-mysql modules. The mysql java connector can be installed using the [puppet/mysql_java_connector](https://forge.puppetlabs.com/puppet/mysql_java_connector) module.
 
 When using this module to upgrade Stash, please make sure you have a database/Stash home backup. We plan to include a class for backing up the stash home directory in a future release.
 
@@ -236,15 +236,6 @@ The database password for the database user. Default: 'password'
 The uri to the stash database server. Default: 'jdbc:postgresql://localhost:5432/stash'
 #####`dbdriver`
 The driver to use to connect to the database. Default: 'org.postgresql.Driver'
-
-####MySQL parameters####
-
-#####`mysql_connector_manage`
-Manage the MySQL java connector. Defaults to true.
-#####`mysql_connector_version`
-Specifies the version of MySQL Java Connector you would like installed. Defaults to '5.1.36' 
-#####`mysql_connector_installdir`
-Installation directory of the MySQL connector. Defaults to '/opt/MySQL-connector'
 
 ####JVM Java parameters####
 

--- a/examples/stash_mysql_java_install.pp
+++ b/examples/stash_mysql_java_install.pp
@@ -1,0 +1,31 @@
+node default {
+
+  $version = '3.9.11'
+
+  include ::java
+  include ::git
+
+  class { '::mysql::server':
+    root_password => 'strongpassword',
+  } ->
+
+  mysql::db { 'stash':
+    user     => 'stash',
+    password => 'password',
+    host     => 'localhost',
+    grant    => ['ALL'],
+  } ->
+
+  class { '::stash':
+    version  => $version,
+    javahome => '/opt/java',
+  } ->
+
+  class { '::mysql_java_connector':
+    links => [ "/opt/stash/atlassian-stash-${version}/lib" ],
+  }
+
+  class { '::stash::facts': }
+
+  
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,11 +76,6 @@ class stash(
   # Choose whether to use puppet-staging, or puppet-archive
   $deploy_module = 'archive',
 
-  # MySQL Connector Settings
-  $mysql_connector_manage     = true,
-  $mysql_connector_version    = '5.1.36',
-  $mysql_connector_installdir = undef,
-
 ) {
 
   validate_hash($config_properties)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,9 +18,6 @@ class stash::install(
   $deploy_module  = $stash::deploy_module,
   $dburl          = $stash::dburl,
   $checksum       = $stash::checksum,
-  $mysqlc_manage  = $stash::mysql_connector_manage,
-  $mysqlc_version = $stash::mysql_connector_version,
-  $mysqlc_install = $stash::mysql_connector_installdir,
   $webappdir,
   ) {
 
@@ -121,14 +118,6 @@ class stash::install(
     command     => "/bin/chown -R ${user}:${group} ${webappdir}",
     refreshonly => true,
     subscribe   => [ User[$user], File[$webappdir] ],
-  }
-
-  if $dburl =~ /jdbc\.url=jdbc:mysql:/ and $mysqlc_manage {
-    class { '::mysql_java_connector':
-      links      => "${webappdir}/lib",
-      version    => $mysqlc_version,
-      installdir => $mysqlc_install,
-    }
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -57,10 +57,6 @@
     {
       "name": "yguenane/repoforge",
       "version_requirement": ">= 0.2.0"
-    },
-    {
-      "name": "puppet/mysql_java_connector",
-      "version_requirement": ">= 1.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/stash_install_spec.rb
+++ b/spec/classes/stash_install_spec.rb
@@ -104,48 +104,6 @@ describe 'stash' do
                                                           'group' => 'bar')
             end
           end
-
-          context 'manage mysql connector' do
-            context 'when dburl parameter is set' do
-              let(:params) do
-                { :version => STASH_VERSION,
-                  :dburl   => 'jdbc.url=jdbc:mysql://localhost:3306/stash?foo?bar?',
-                }
-              end
-              it do
-                should contain_class('mysql_java_connector')
-                  .with('links'      => "/opt/stash/atlassian-stash-#{STASH_VERSION}/lib",
-                        'version'    => '5.1.36',
-                        'installdir' => '/opt/MySQL-connector',)
-              end
-            end
-            context 'when dburl parameter is not set' do
-              it { should_not contain_class('mysql_java_connector') }
-            end
-            context 'mysql connector is disabled' do
-              let(:params) do
-                { :dburl => 'jdbc.url=jdbc:mysql://localhost:3306/stash?foo?bar?',
-                  :mysql_connector_manage => false,
-                }
-              end
-              it { should_not contain_class('mysql_java_connector') }
-            end
-            context 'when dburl parameter is set with custom params' do
-              let(:params) do
-                { :version                    => '99.0.0',
-                  :dburl                      => 'jdbc.url=jdbc:mysql://localhost:3306/stash?foo?bar?',
-                  :mysql_connector_version    => '5.99.111',
-                  :mysql_connector_installdir => '/opt/custom',
-                }
-              end
-              it do
-                should contain_class('mysql_java_connector')
-                  .with('links'      => '/opt/stash/atlassian-stash-99.0.0/lib',
-                        'version'    => '5.99.111',
-                        'installdir' => '/opt/custom',)
-              end
-            end
-          end
         end
       end
     end


### PR DESCRIPTION
The connector can be installed using the puppet/mysql_java_connector
module inside a stash profile.
