### PR TITLE
Set mysql driver in stash-config.properties for mysql example

### DIFF
--- a/examples/stash_mysql_java_install.pp
+++ b/examples/stash_mysql_java_install.pp
@@ -19,10 +19,12 @@ node default {
   class { '::stash':
     version  => $version,
     javahome => '/opt/java',
+    dbdriver => 'com.mysql.jdbc.Driver',
   } ->
 
   class { '::mysql_java_connector':
-    links => [ "/opt/stash/atlassian-stash-${version}/lib" ],
+    links    => [ "/opt/stash/atlassian-stash-${version}/lib" ],
+    notify   => Service['stash'],
   }
 
   class { '::stash::facts': }

--- a/examples/stash_mysql_java_install.pp
+++ b/examples/stash_mysql_java_install.pp
@@ -23,8 +23,8 @@ node default {
   } ->
 
   class { '::mysql_java_connector':
-    links    => [ "/opt/stash/atlassian-stash-${version}/lib" ],
-    notify   => Service['stash'],
+    links  => [ "/opt/stash/atlassian-stash-${version}/lib" ],
+    notify => Service['stash'],
   }
 
   class { '::stash::facts': }


### PR DESCRIPTION
Small fix. Ensure mysql driver is set in stash-config.properties (Otherwise we get a 'no suitable driver found').
