### PR TITLE
Auto set product based on version variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,6 @@ class stash(
 
   # Stash Settings
   $version      = '3.7.0',
-  $product      = 'stash',
   $format       = 'tar.gz',
   $installdir   = '/opt/stash',
   $homedir      = '/home/stash',
@@ -77,6 +76,11 @@ class stash(
   $deploy_module = 'archive',
 
 ) {
+
+  case $version {
+    /[1-3]\..*/: { $product = 'stash' }
+    default:     { $product = 'product' }
+  }
 
   validate_hash($config_properties)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,7 +79,7 @@ class stash(
 
   case $version {
     /[1-3]\..*/: { $product = 'stash' }
-    default:     { $product = 'product' }
+    default:     { $product = 'bitbucket' }
   }
 
   validate_hash($config_properties)


### PR DESCRIPTION
Kind of redundant variable set (If we know the version we know the product). Looking at the history of this module it seems that $product is coming from a 'generic' atlassian module (Jira, confluence, stash, etc..). So we don't get rid of it (as needed by other classes/resources) but simply auto set it based on the version provided.

Let me know what you think about this one.
