### PR TITLE
Allow stash-config.properties to be configured using hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ Enable the repoforge yum repository by default for RHEL as stash requires a newe
 By default we will upgrade git to a supported version if it is already installed and the repoforge repository was not enabled. Default: true
 #####`$staging_or_deploy`
 Choose whether to use nanliu-staging, or mkrakowitzer-deploy. Defaults to 'staging' to use nanliu-staging as it is puppetlabs approved. Alternative option is 'deploy' to use mkrakowitzer-deploy.
+#####`$config_properties`
+Allow arbitrary config properties to be set in stash-config.properties using hiera
 
 ####Backup parameters####
 #####`backup_ensure`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,6 +80,9 @@ class stash(
   # Defaults to nanliu-staging as it is puppetlabs approved.
   $staging_or_deploy = 'staging',
 
+  # Allow arbitrary config properties to be set in stash-config.properties using hiera
+  $config_properties = {},
+
 ) {
 
   validate_bool($git_manage)

--- a/templates/stash-config.properties.erb
+++ b/templates/stash-config.properties.erb
@@ -11,3 +11,6 @@ jdbc.driver=<%= scope.lookupvar('stash::dbdriver') %>
 jdbc.url=<%= scope.lookupvar('stash::dburl') %>
 jdbc.user=<%= scope.lookupvar('stash::dbuser') %>
 jdbc.password=<%= scope.lookupvar('stash::dbpassword') %>
+<% @config_properties.sort.each do |key,value| -%>
+<%= key %>=<%= value %>
+<% end -%>


### PR DESCRIPTION
I understand that master is undergoing a large refactor to support upgrades to bitbucket server, so I have branched a the latest release 1.3.0 to so that people may upgrade this module while they are waiting.
