### PR TITLE
Add checksum for modules default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Where to download the stash binaries from. Default: <http://www.atlassian.com/so
 ##### `checksum`
 
 The md5 checksum of the archive file. Only supported with `deploy_module => archive`.
-Defaults to 'undef'
+Defaults to '6fc33bfca7eaba66bed8b980a58c71c0'
 
 ##### `service_manage`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@ class stash(
 
   # Misc Settings
   $download_url = 'http://www.atlassian.com/software/stash/downloads/binary/',
-  $checksum     = undef,
+  $checksum     = '6fc33bfca7eaba66bed8b980a58c71c0',
 
   # Backup Settings
   $backup_ensure          = 'present',


### PR DESCRIPTION
As long as Atlassian does not provide checksums, we should at least supply one for the default version so that the installation is as straightforward as possible.