### PR TITLE
Use https instead of http

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,8 @@ Reverse https proxy configuration. See examples for more detail. Default: {}
 
 ##### `download_url`
 
-Where to download the stash binaries from. Default: <http://www.atlassian.com/software/stash/downloads/binary/>
+The URL used to download the Stash installation file.
+Defaults to '<https://www.atlassian.com/software/stash/downloads/binary>'
 
 ##### `checksum`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,7 @@ class stash(
   $dbdriver     = 'org.postgresql.Driver',
 
   # Misc Settings
-  $download_url = 'http://www.atlassian.com/software/stash/downloads/binary/',
+  $download_url = 'https://www.atlassian.com/software/stash/downloads/binary',
   $checksum     = undef,
 
   # Backup Settings

--- a/spec/classes/stash_install_spec.rb
+++ b/spec/classes/stash_install_spec.rb
@@ -17,11 +17,11 @@ describe 'stash' do
 
           it 'deploys stash from archive' do
             is_expected.to contain_archive("/tmp/atlassian-stash-#{STASH_VERSION}.tar.gz").
-              with('extract_path' => "/opt/stash/atlassian-stash-#{STASH_VERSION}",
-                   'source' => "http://www.atlassian.com/software/stash/downloads/binary//atlassian-stash-#{STASH_VERSION}.tar.gz",
-                   'creates' => "/opt/stash/atlassian-stash-#{STASH_VERSION}/conf",
-                   'user' => 'stash',
-                   'group' => 'stash',
+              with('extract_path'  => "/opt/stash/atlassian-stash-#{STASH_VERSION}",
+                   'source'        => "https://www.atlassian.com/software/stash/downloads/binary/atlassian-stash-#{STASH_VERSION}.tar.gz",
+                   'creates'       => "/opt/stash/atlassian-stash-#{STASH_VERSION}/conf",
+                   'user'          => 'stash',
+                   'group'         => 'stash',
                    'checksum_type' => 'md5')
           end
 


### PR DESCRIPTION
We should use https instead of http, even if Atlassian redirects the traffic automatically.