### PR TITLE
Exposes checksum_verify in init.pp w/ conditional.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,13 @@ class stash(
     fail('You need to specify a value for javahome')
   }
 
+  # Archive module checksum_verify = true; this verifies checksum if provided, doesn't if not.
+  if $checksum == undef {
+    $checksum_verify = false
+  } else {
+    $checksum_verify = true
+  }
+
   anchor { 'stash::start': } ->
   class { '::stash::install': webappdir => $webappdir, } ->
   class { '::stash::config': } ~>

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -92,6 +92,7 @@ class stash::install(
         source          => "${download_url}/${file}",
         creates         => "${webappdir}/conf",
         cleanup         => true,
+        checksum_verify => $stash::checksum_verify,
         checksum_type   => 'md5',
         checksum        => $checksum,
         user            => $user,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.

-->

This PR exposes checksum_verify (as the default for that is 'true' in archive module) in install.pp and exposes it with a conditional in init.pp instead. It sets the value depending on whether checksum is defined by user and performs the check, otherwise it does no check.
@dhoppe @afisher @bbriggs @bastelfreak (and anyone else), please review. Thanks!