### PR TITLE
Bump min version_requirement for Puppet + deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Minute schedule for when to perform backup. Defaults to '0'.
 
 ## Limitations
 
-* Puppet 3.4+
+* Puppet 3.8.7+
 * Puppet Enterprise
 
 The puppetlabs repositories can be found at:

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "puppet-stash",
   "version": "2.0.0",
-  "author": "puppet",
+  "author": "Vox Pupuli",
   "summary": "Install Atlassian stash",
   "license": "MIT",
   "source": "https://github.com/voxpupuli/puppet-stash.git",
@@ -41,29 +41,25 @@
   "dependencies": [
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 0.4.4"
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">=1.4.1 < 2.0.0"
     },
     {
       "name": "puppet/staging",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 2.0.1 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">=3.4.0 <4.0.0"
+      "version_requirement": ">=3.8.7 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata

Also remove deprecated pe version_requirement field

Also fix author