### PR TITLE
use Puppet Ruby for fact, use stash port from main class, remove ruby extension packages

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -20,7 +20,6 @@ class stash::facts (
   $uri           = '127.0.0.1',
   $ruby_bin      = '/opt/puppetlabs/puppet/bin/ruby',
   $context_path  = $stash::context_path,
-  $json_packages = $stash::params::json_packages,
 ) inherits stash {
   if ! defined(File['/etc/facter']) {
     file { '/etc/facter':

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -21,7 +21,6 @@ class stash::facts (
   $ruby_bin      = '/opt/puppetlabs/puppet/bin/ruby',
   $context_path  = $stash::context_path,
 ) inherits stash {
-
   if ! defined(File['/etc/facter']) {
     file { '/etc/facter':
       ensure  => directory,

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -18,37 +18,23 @@ class stash::facts (
   $ensure        = 'present',
   $port          = '7990',
   $uri           = '127.0.0.1',
+  $ruby_bin      = '/opt/puppetlabs/puppet/bin/ruby',
   $context_path  = $stash::context_path,
   $json_packages = $stash::params::json_packages,
 ) inherits stash {
-  # Puppet Enterprise supplies its own ruby version if your using it.
-  # A modern ruby version is required to run the executable fact
-  if $::puppetversion =~ /Puppet Enterprise/ {
-    $ruby_bin = '/opt/puppet/bin/ruby'
-    $dir      = 'puppetlabs/'
-  } else {
-    $ruby_bin = '/usr/bin/env ruby'
-    $dir      = ''
-  }
 
-  if ! defined(File["/etc/${dir}facter"]) {
-    file { "/etc/${dir}facter":
+  if ! defined(File['/etc/facter']) {
+    file { '/etc/facter':
       ensure  => directory,
     }
   }
-  if ! defined(File["/etc/${dir}facter/facts.d"]) {
-    file { "/etc/${dir}facter/facts.d":
+  if ! defined(File['/etc/facter/facts.d']) {
+    file { '/etc/facter/facts.d':
       ensure  => directory,
     }
   }
 
-  if $facts['os']['family'] == 'RedHat' and $::puppetversion !~ /Puppet Enterprise/ {
-    package { $json_packages:
-      ensure => present,
-    }
-  }
-
-  file { "/etc/${dir}facter/facts.d/stash_facts.rb":
+  file { '/etc/facter/facts.d/stash_facts.rb':
     ensure  => $ensure,
     content => template('stash/facts.rb.erb'),
     mode    => '0500',

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -21,6 +21,7 @@ class stash::facts (
   $ruby_bin      = '/opt/puppetlabs/puppet/bin/ruby',
   $context_path  = $stash::context_path,
 ) inherits stash {
+
   if ! defined(File['/etc/facter']) {
     file { '/etc/facter':
       ensure  => directory,

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -16,13 +16,12 @@
 #
 class stash::facts (
   $ensure        = 'present',
-  $port          = '7990',
+  $port          = $stash::tomcat_port,
   $uri           = '127.0.0.1',
   $ruby_bin      = '/opt/puppetlabs/puppet/bin/ruby',
   $context_path  = $stash::context_path,
   $json_packages = $stash::params::json_packages,
 ) inherits stash {
-
   if ! defined(File['/etc/facter']) {
     file { '/etc/facter':
       ensure  => directory,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,6 @@ class stash::params {
   case $facts['os']['family'] {
     /RedHat/: {
       if $facts['os']['release']['major'] == '7' {
-        $json_packages           = 'rubygem-json'
         $service_file_location   = '/usr/lib/systemd/system/stash.service'
         $service_file_template   = 'stash/stash.service.epp'
         $service_lockfile        = '/var/lock/subsys/stash'
@@ -20,8 +19,6 @@ class stash::params {
       }
     }
     /Debian/: {
-      $json_packages           = ['rubygem-json', 'ruby-json']
-
       if $facts['os']['release']['full'] == '18.04' {
         $service_file_location   = '/etc/systemd/system/stash.service'
         $service_file_template   = 'stash/stash.service.epp'

--- a/spec/classes/stash_facts_spec.rb
+++ b/spec/classes/stash_facts_spec.rb
@@ -10,9 +10,7 @@ describe 'stash::facts', type: :class do
           facts
         end
 
-        regexp_pe = %r{^#!/opt/puppet/bin/ruby$}
-        regexp_oss = %r{^#!/usr/bin/env ruby$}
-        pe_external_fact_file = '/etc/puppetlabs/facter/facts.d/stash_facts.rb'
+        regexp_rubypath = %r{/opt/puppetlabs/puppet/bin/ruby}
         external_fact_file = '/etc/facter/facts.d/stash_facts.rb'
 
         it { is_expected.to contain_file(external_fact_file) }
@@ -24,8 +22,8 @@ describe 'stash::facts', type: :class do
           end
 
           it do
-            is_expected.to contain_file(pe_external_fact_file). \
-              with_content(regexp_pe)
+            is_expected.to contain_file(external_fact_file). \
+              with_content(regexp_rubypath)
           end
         end
 
@@ -33,7 +31,7 @@ describe 'stash::facts', type: :class do
         context 'with puppet oss' do
           it do
             is_expected.to contain_file(external_fact_file). \
-              with_content(regexp_oss).
+              with_content(regexp_rubypath).
               with_content(%r{7990/rest/api/})
           end
         end


### PR DESCRIPTION
* This module supports Puppet 5.5.8+, which indicates, it can use the bundled Ruby
* The bundled Ruby also provides JSON support
* reference to system Ruby removed
* install of JSON extension removed
* the port used by Stash/Bitbucket is already set in the main class and can be used from there